### PR TITLE
initial support for font json files - only tested with command line 

### DIFF
--- a/custom_components/ipixel_color/fonts/3x5-de.json
+++ b/custom_components/ipixel_color/fonts/3x5-de.json
@@ -1,0 +1,23 @@
+{
+  "name": "3x5-de",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/5x5.json
+++ b/custom_components/ipixel_color/fonts/5x5.json
@@ -1,0 +1,23 @@
+{
+  "name": "5x5",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/7x5.json
+++ b/custom_components/ipixel_color/fonts/7x5.json
@@ -1,0 +1,23 @@
+{
+  "name": "7x5",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/OpenSans-Light.json
+++ b/custom_components/ipixel_color/fonts/OpenSans-Light.json
@@ -1,0 +1,23 @@
+{
+  "name": "OpenSans-Light",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, -5],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/WP7xn.json
+++ b/custom_components/ipixel_color/fonts/WP7xn.json
@@ -3,7 +3,7 @@
   "metrics": {
     "16": {
       "font_size": 16,
-      "offset": [0, -5],
+      "offset": [0, -9],
       "pixel_threshold": 70,
       "var_width": true 
     },

--- a/custom_components/ipixel_color/fonts/WP7xn.json
+++ b/custom_components/ipixel_color/fonts/WP7xn.json
@@ -1,0 +1,23 @@
+{
+  "name": "WP7xn",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, -5],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}


### PR DESCRIPTION
tested with pypixelcolor.py command line not ha-integration due to other issues i am having

tested for font size 16 - other font sizes will need others to test and set Y offsets (i only editied y offsets)

did not expermined with pixel-threshold