### PR TITLE
initial font json files

### DIFF
--- a/custom_components/ipixel_color/fonts/3x5-de.json
+++ b/custom_components/ipixel_color/fonts/3x5-de.json
@@ -1,0 +1,23 @@
+{
+  "name": "3x5-de",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/3x5-de.json
+++ b/custom_components/ipixel_color/fonts/3x5-de.json
@@ -2,8 +2,8 @@
   "name": "3x5-de",
   "metrics": {
     "16": {
-      "font_size": 16,
-      "offset": [0, 0],
+      "font_size": 12,
+      "offset": [0, 3],
       "pixel_threshold": 70,
       "var_width": true 
     },

--- a/custom_components/ipixel_color/fonts/5x5.json
+++ b/custom_components/ipixel_color/fonts/5x5.json
@@ -1,0 +1,23 @@
+{
+  "name": "5x5",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/5x5.json
+++ b/custom_components/ipixel_color/fonts/5x5.json
@@ -2,8 +2,8 @@
   "name": "5x5",
   "metrics": {
     "16": {
-      "font_size": 16,
-      "offset": [0, 0],
+      "font_size": 24,
+      "offset": [0, -8],
       "pixel_threshold": 70,
       "var_width": true 
     },

--- a/custom_components/ipixel_color/fonts/7x5.json
+++ b/custom_components/ipixel_color/fonts/7x5.json
@@ -1,0 +1,23 @@
+{
+  "name": "7x5",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, 0],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/7x5.json
+++ b/custom_components/ipixel_color/fonts/7x5.json
@@ -3,7 +3,7 @@
   "metrics": {
     "16": {
       "font_size": 16,
-      "offset": [0, 0],
+      "offset": [0, -1],
       "pixel_threshold": 70,
       "var_width": true 
     },

--- a/custom_components/ipixel_color/fonts/OpenSans-Light.json
+++ b/custom_components/ipixel_color/fonts/OpenSans-Light.json
@@ -1,0 +1,23 @@
+{
+  "name": "OpenSans-Light",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, -5],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/OpenSans-Light.json
+++ b/custom_components/ipixel_color/fonts/OpenSans-Light.json
@@ -2,9 +2,9 @@
   "name": "OpenSans-Light",
   "metrics": {
     "16": {
-      "font_size": 16,
-      "offset": [0, -5],
-      "pixel_threshold": 70,
+      "font_size": 14,
+      "offset": [0, -3],
+      "pixel_threshold": 50,
       "var_width": true 
     },
     "24": {

--- a/custom_components/ipixel_color/fonts/WP7xn.json
+++ b/custom_components/ipixel_color/fonts/WP7xn.json
@@ -3,7 +3,7 @@
   "metrics": {
     "16": {
       "font_size": 16,
-      "offset": [0, -5],
+      "offset": [0, -9],
       "pixel_threshold": 70,
       "var_width": true 
     },

--- a/custom_components/ipixel_color/fonts/WP7xn.json
+++ b/custom_components/ipixel_color/fonts/WP7xn.json
@@ -1,0 +1,23 @@
+{
+  "name": "WP7xn",
+  "metrics": {
+    "16": {
+      "font_size": 16,
+      "offset": [0, -5],
+      "pixel_threshold": 70,
+      "var_width": true 
+    },
+    "24": {
+      "font_size": 24,
+      "offset": [0, -1],
+      "pixel_threshold": 80,
+      "var_width": true
+    },
+    "32": {
+      "font_size": 25,
+      "offset": [0, 2],
+      "pixel_threshold": 85,
+      "var_width": true
+    }
+  }
+}

--- a/custom_components/ipixel_color/fonts/WP7xn.json
+++ b/custom_components/ipixel_color/fonts/WP7xn.json
@@ -2,9 +2,9 @@
   "name": "WP7xn",
   "metrics": {
     "16": {
-      "font_size": 16,
-      "offset": [0, -9],
-      "pixel_threshold": 70,
+      "font_size": 14,
+      "offset": [0, -6],
+      "pixel_threshold": 30,
       "var_width": true 
     },
     "24": {


### PR DESCRIPTION
only the size 16 font section of each file was tweaked
testing based on usage with pypixelcolor.py not the HA integration

learnings:
only 3 font selection defintions possible
font can be specified as smaller or larger than font selection as needed based on font
Y offsert was adjust to prevent vertical truncation

only tested on my device YMMV