### PR TITLE
Modified font size setting in text_mode_pypixelcolor

### DIFF
--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -273,7 +273,8 @@ class iPIXELAPI:
         font: str = "CUSONG",
         animation: int = 0,
         speed: int = 80,
-        rainbow_mode: int = 0
+        rainbow_mode: int = 0,
+        font_size: int = 16
     ) -> bool:
         """Display text using pypixelcolor.
 
@@ -285,6 +286,7 @@ class iPIXELAPI:
             animation: Animation type (0-7)
             speed: Animation speed (0-100)
             rainbow_mode: Rainbow mode (0-9)
+            font_size: Font size (16, 32, 48, 64) defaults to 16
 
         Returns:
             True if text was sent successfully
@@ -293,6 +295,12 @@ class iPIXELAPI:
             # Get device info for height
             device_info = await self.get_device_info()
             device_height = device_info["height"]
+
+            if font_size > device_height:
+                font_size = device_height
+            if font_size < 16:
+                font_size = 16
+            char_height = floor(font_size / 16) * 16
 
             # Generate text commands using pypixelcolor
             commands = make_text_command(
@@ -304,7 +312,7 @@ class iPIXELAPI:
                 speed=speed,
                 rainbow_mode=rainbow_mode,
                 save_slot=0,
-                device_height=device_height
+                char_height=char_height
             )
 
             # Send all command frames

--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any, TYPE_CHECKING
+from math import floor
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/ipixel_color/common.py
+++ b/custom_components/ipixel_color/common.py
@@ -313,6 +313,12 @@ async def _update_text_mode(hass: HomeAssistant, device_name: str, api, text: st
         if speed is None:
             speed = 80  # Default speed
 
+        # Font size - need new number entity
+        font_size = await _get_entity_setting(hass, device_name, "number", "font_size", float, api._address)
+        if font_size is None:
+            speed = 16  # Default font_size
+        font_size = int(font_size)
+
         # Rainbow mode - need new number entity
         rainbow_mode = await _get_entity_setting(hass, device_name, "number", "text_rainbow", int, api._address)
         if rainbow_mode is None:
@@ -335,7 +341,8 @@ async def _update_text_mode(hass: HomeAssistant, device_name: str, api, text: st
             font=font,
             animation=animation,
             speed=speed,
-            rainbow_mode=rainbow_mode
+            rainbow_mode=rainbow_mode,
+            font_size=font_size
         )
 
         if success:

--- a/custom_components/ipixel_color/device/text.py
+++ b/custom_components/ipixel_color/device/text.py
@@ -20,7 +20,7 @@ def make_text_command(
     speed: int = 80,
     rainbow_mode: int = 0,
     save_slot: int = 0,
-    device_height: Optional[int] = None
+    char_height: Optional[int] = None
 ) -> list[bytes]:
     """Build text display command using pypixelcolor.
 
@@ -33,7 +33,7 @@ def make_text_command(
         speed: Animation speed (0-100)
         rainbow_mode: Rainbow mode (0-9)
         save_slot: Save slot (0-255)
-        device_height: Device height in pixels (auto-detected if None)
+        char_height: Character height in pixels (auto-detected if None)
 
     Returns:
         List of command bytes (one per window/frame)
@@ -55,7 +55,7 @@ def make_text_command(
         speed=speed,
         rainbow_mode=rainbow_mode,
         save_slot=save_slot,
-        char_height=device_height
+        char_height=char_height
     )
 
     # Extract command bytes from all windows


### PR DESCRIPTION
I found font_size did not apply if using mode:text however the app does provide this.
I have modified the naming and normalized inputs when sending text as text (not textImage):
1. If font_size is below 16 use 16.
2. If font_size is bigger than device_height use device_height.
3. Only use multiplies of 16. char_height = math.floor(font_size/16)*16