### PR TITLE
Add show_emoji service with async Twemoji rendering

### DIFF
--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import logging
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 
 from .api import iPIXELAPI, iPIXELConnectionError, iPIXELTimeoutError
 from .const import DOMAIN, CONF_ADDRESS, CONF_NAME
@@ -15,6 +18,64 @@ _LOGGER = logging.getLogger(__name__)
 
 # Platforms supported by this integration
 PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.TEXT, Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.LIGHT]
+
+SERVICE_SHOW_EMOJI = "show_emoji"
+
+SHOW_EMOJI_SCHEMA = vol.Schema(
+    {
+        vol.Required("emoji"): vol.All(str, vol.Length(min=1)),
+        vol.Optional("device_id"): str,
+        vol.Optional("bg_color"): vol.All(
+            [vol.All(int, vol.Range(min=0, max=255))], vol.Length(min=3, max=3)
+        ),
+        vol.Optional("width"): vol.All(int, vol.Range(min=1, max=512)),
+        vol.Optional("height"): vol.All(int, vol.Range(min=1, max=512)),
+    }
+)
+
+
+def _resolve_api(hass: HomeAssistant, call: ServiceCall) -> iPIXELAPI:
+    """Resolve which iPIXEL API instance to use from a service call."""
+    apis: dict[str, iPIXELAPI] = hass.data.get(DOMAIN, {})
+    if not apis:
+        raise HomeAssistantError("No iPIXEL devices are configured")
+
+    raw = call.data.get("device_id")
+    if not raw:
+        target = getattr(call, "target", None) or {}
+        raw = target.get("device_id") if isinstance(target, dict) else None
+    target_device_ids = [raw] if isinstance(raw, str) else (raw or [])
+
+    if not target_device_ids:
+        if len(apis) == 1:
+            return next(iter(apis.values()))
+        raise HomeAssistantError(
+            "Multiple iPIXEL devices configured — specify a device_id"
+        )
+
+    device_reg = dr.async_get(hass)
+    for device_id in target_device_ids:
+        device = device_reg.async_get(device_id)
+        if not device:
+            continue
+        for entry_id in device.config_entries:
+            if entry_id in apis:
+                return apis[entry_id]
+
+    raise HomeAssistantError(f"No iPIXEL device matched {target_device_ids}")
+
+
+async def _handle_show_emoji(hass: HomeAssistant, call: ServiceCall) -> None:
+    api = _resolve_api(hass, call)
+    emoji = call.data["emoji"]
+    bg_rgb = call.data.get("bg_color")
+    bg_color = "{:02x}{:02x}{:02x}".format(*bg_rgb) if bg_rgb else "000000"
+    await api.display_emoji(
+        emoji,
+        bg_color=bg_color,
+        width_override=call.data.get("width"),
+        height_override=call.data.get("height"),
+    )
 
 # Type alias for iPIXEL config entries
 
@@ -51,10 +112,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api
     entry.runtime_data = api
-    
+
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
+
+    # Register integration services once (first entry to load)
+    if not hass.services.has_service(DOMAIN, SERVICE_SHOW_EMOJI):
+        async def _show_emoji_service(call: ServiceCall) -> None:
+            await _handle_show_emoji(hass, call)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SHOW_EMOJI,
+            _show_emoji_service,
+            schema=SHOW_EMOJI_SCHEMA,
+        )
+
     return True
 
 

--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -24,7 +24,7 @@ SERVICE_SHOW_EMOJI = "show_emoji"
 SHOW_EMOJI_SCHEMA = vol.Schema(
     {
         vol.Required("emoji"): vol.All(str, vol.Length(min=1)),
-        vol.Optional("device_id"): str,
+        vol.Optional("device_id"): vol.Any(None, str, [str]),
         vol.Optional("bg_color"): vol.All(
             [vol.All(int, vol.Range(min=0, max=255))], vol.Length(min=3, max=3)
         ),

--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -18,6 +18,7 @@ from .device.text import make_text_command
 from .device.image import make_image_command
 from .device.info import build_device_info_command, parse_device_response
 from .display.text_renderer import render_text_to_png
+from .display.emoji_renderer import render_emoji_to_png
 from .exceptions import iPIXELConnectionError
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class iPIXELAPI:
             hass: Home Assistant instance
             address: Bluetooth MAC address
         """
+        self._hass = hass
         self._address = address
         self._bluetooth = BluetoothClient(hass, address)
         self._power_state = False
@@ -334,6 +336,69 @@ class iPIXELAPI:
 
         except Exception as err:
             _LOGGER.error("Error displaying pypixelcolor text: %s", err)
+            return False
+
+    async def display_emoji(
+        self,
+        emoji: str,
+        bg_color: str = "000000",
+        width_override: int | None = None,
+        height_override: int | None = None,
+    ) -> bool:
+        """Display an emoji as a Twemoji image, downloaded async and cached locally.
+
+        Unlike display_text_pypixelcolor (which delegates emoji handling to
+        pypixelcolor and currently triggers a blocking HTTP call inside the
+        event loop), this method downloads the Twemoji PNG asynchronously,
+        caches it under hass.config.path(".storage/ipixel_emoji_cache"), and
+        composes it onto a canvas matching the device dimensions.
+
+        Args:
+            emoji: Unicode emoji character (e.g. '🔔', '🚨', '⚠️')
+            bg_color: Background color in hex (default '000000')
+            width_override: Optional canvas width override. Useful when the
+                firmware reports incorrect dimensions for the physical panel.
+                Defaults to device_info width.
+            height_override: Optional canvas height override.
+
+        Returns:
+            True if the emoji was rendered and sent successfully.
+        """
+        try:
+            base_info = await self.get_device_info()
+            width = width_override or base_info["width"]
+            height = height_override or base_info["height"]
+            device_info = {**base_info, "width": width, "height": height}
+
+            png_data = await render_emoji_to_png(self._hass, emoji, width, height, bg_color)
+            if png_data is None:
+                _LOGGER.error("Could not render emoji %r (download or cache miss)", emoji)
+                return False
+
+            commands = make_image_command(
+                image_bytes=png_data,
+                file_extension=".png",
+                resize_method="crop",
+                device_info_dict=device_info,
+            )
+
+            if not self.is_connected:
+                await self.connect()
+
+            for i, command in enumerate(commands):
+                success = await self._bluetooth.send_command(command)
+                if not success:
+                    _LOGGER.error("Failed to send emoji frame %d/%d", i + 1, len(commands))
+                    return False
+
+            _LOGGER.info(
+                "Emoji %r displayed (%dx%d, %d frames)",
+                emoji, width, height, len(commands),
+            )
+            return True
+
+        except Exception as err:
+            _LOGGER.exception("Error displaying emoji %r: %s", emoji, err)
             return False
 
     def _notification_handler(self, sender: Any, data: bytearray) -> None:

--- a/custom_components/ipixel_color/display/emoji_renderer.py
+++ b/custom_components/ipixel_color/display/emoji_renderer.py
@@ -1,0 +1,129 @@
+"""Emoji rendering for iPIXEL Color displays.
+
+Downloads Twemoji PNGs asynchronously (cached locally) and composes them
+onto a canvas matching the device dimensions reported by the firmware.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from pathlib import Path
+
+import aiohttp
+from PIL import Image
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ..color import hex_to_rgb
+
+_LOGGER = logging.getLogger(__name__)
+
+TWEMOJI_CDN = "https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/72x72/{cp}.png"
+CACHE_DIRNAME = "ipixel_emoji_cache"
+DOWNLOAD_TIMEOUT = 10  # seconds
+
+
+def _emoji_to_codepoint(emoji: str) -> str:
+    """Convert an emoji string to Twemoji's filename codepoint format.
+
+    Twemoji strips the FE0F variation selector but keeps ZWJ sequences
+    (e.g. family emojis). Returns codepoints joined by '-'.
+    """
+    parts = [f"{ord(c):x}" for c in emoji if c != "\ufe0f"]
+    return "-".join(parts)
+
+
+async def _fetch_emoji_png(hass: HomeAssistant, codepoint: str) -> bytes | None:
+    """Fetch the Twemoji PNG for a codepoint, with on-disk caching."""
+    cache_dir = Path(hass.config.path(".storage", CACHE_DIRNAME))
+    await hass.async_add_executor_job(
+        lambda: cache_dir.mkdir(parents=True, exist_ok=True)
+    )
+
+    cached_path = cache_dir / f"{codepoint}.png"
+    if cached_path.exists():
+        return await hass.async_add_executor_job(cached_path.read_bytes)
+
+    url = TWEMOJI_CDN.format(cp=codepoint)
+    session = async_get_clientsession(hass)
+    try:
+        async with asyncio.timeout(DOWNLOAD_TIMEOUT):
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    _LOGGER.warning("Twemoji %s not found at %s (HTTP %s)", codepoint, url, resp.status)
+                    return None
+                data = await resp.read()
+    except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+        _LOGGER.error("Failed to fetch Twemoji %s: %s", codepoint, err)
+        return None
+
+    await hass.async_add_executor_job(cached_path.write_bytes, data)
+    return data
+
+
+def _compose_emoji_image(
+    emoji_png: bytes,
+    canvas_width: int,
+    canvas_height: int,
+    bg_color: str = "000000",
+) -> bytes:
+    """Compose an emoji PNG onto a canvas, preserving aspect ratio.
+
+    The emoji is scaled so that its longest side fits within the canvas
+    (minus 2px padding) and centered. Background uses bg_color.
+    """
+    try:
+        bg_r, bg_g, bg_b = hex_to_rgb(bg_color)
+    except (ValueError, IndexError):
+        bg_r, bg_g, bg_b = 0, 0, 0
+
+    canvas = Image.new("RGB", (canvas_width, canvas_height), (bg_r, bg_g, bg_b))
+
+    src = Image.open(io.BytesIO(emoji_png)).convert("RGBA")
+    target = min(canvas_width, canvas_height)
+    scale = max(1, target - 2) / max(src.width, src.height)
+    new_w = max(1, int(src.width * scale))
+    new_h = max(1, int(src.height * scale))
+    resized = src.resize((new_w, new_h), Image.LANCZOS)
+
+    x = (canvas_width - new_w) // 2
+    y = (canvas_height - new_h) // 2
+    canvas.paste(resized, (x, y), resized)
+
+    out = io.BytesIO()
+    canvas.save(out, format="PNG")
+    return out.getvalue()
+
+
+async def render_emoji_to_png(
+    hass: HomeAssistant,
+    emoji: str,
+    canvas_width: int,
+    canvas_height: int,
+    bg_color: str = "000000",
+) -> bytes | None:
+    """Render an emoji onto a canvas of the given dimensions.
+
+    Returns PNG bytes ready for make_image_command, or None if the emoji
+    could not be fetched.
+    """
+    codepoint = _emoji_to_codepoint(emoji)
+    if not codepoint:
+        _LOGGER.warning("Empty emoji codepoint for %r", emoji)
+        return None
+
+    png_data = await _fetch_emoji_png(hass, codepoint)
+    if png_data is None and "-" in codepoint:
+        # Fallback: try first codepoint only (some ZWJ sequences are not in Twemoji)
+        first = codepoint.split("-")[0]
+        _LOGGER.debug("Falling back to base codepoint %s for emoji %r", first, emoji)
+        png_data = await _fetch_emoji_png(hass, first)
+
+    if png_data is None:
+        return None
+
+    return await hass.async_add_executor_job(
+        _compose_emoji_image, png_data, canvas_width, canvas_height, bg_color
+    )

--- a/custom_components/ipixel_color/manifest.json
+++ b/custom_components/ipixel_color/manifest.json
@@ -29,5 +29,5 @@
     "pillow>=10.0.0",
     "pypixelcolor>=0.4.0"
   ],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/ipixel_color/services.yaml
+++ b/custom_components/ipixel_color/services.yaml
@@ -1,3 +1,52 @@
+show_emoji:
+  name: Show Emoji
+  description: >
+    Display an emoji (Twemoji) on the iPIXEL device. The PNG is downloaded
+    once from the Twemoji CDN, cached locally, and rendered at the device
+    dimensions. Useful for HA notifications (doorbell, alerts, etc.).
+  target:
+    device:
+      integration: ipixel_color
+  fields:
+    emoji:
+      name: Emoji
+      description: A single emoji character (or sequence) to display
+      required: true
+      example: "🔔"
+      selector:
+        text:
+    bg_color:
+      name: Background Color
+      description: Background color (defaults to black)
+      required: false
+      default: [0, 0, 0]
+      selector:
+        color_rgb:
+    width:
+      name: Width override
+      description: >
+        Optional canvas width override. Use only if the firmware reports
+        incorrect dimensions for your panel. Default: device-reported width.
+      required: false
+      example: 32
+      selector:
+        number:
+          min: 1
+          max: 512
+          mode: box
+    height:
+      name: Height override
+      description: >
+        Optional canvas height override. Use only if the firmware reports
+        incorrect dimensions for your panel. Default: device-reported height.
+      required: false
+      example: 32
+      selector:
+        number:
+          min: 1
+          max: 512
+          mode: box
+
 display_text:
   name: Display Text
   description: Display text on the iPIXEL device with custom effects and colors


### PR DESCRIPTION
## Summary

Adds a new service `ipixel_color.show_emoji` that displays an emoji on the panel, intended for HA notifications (doorbell, weather, alerts, status indicators, etc.).

The existing `display_text_pypixelcolor` path advertises emoji support, but in practice `pypixelcolor.lib.emoji_manager` does a **blocking HTTP call inside the event loop** when an emoji is encountered:

```
ERROR pypixelcolor.lib.emoji_manager] Failed to download emoji 🔔 (1f514):
Caught blocking call to putrequest with args (...)
'GET', '/gh/twitter/twemoji@latest/assets/72x72/1f514.png'
inside the event loop by custom integration 'ipixel_color' ...
```

Home Assistant detects and aborts this for stability, so emojis silently never render via that path.

This PR sidesteps the upstream library bug by handling emoji rendering ourselves, properly async.

## What it does

- **`display/emoji_renderer.py` (new)** — fetches the Twemoji PNG via `aiohttp` (async, no blocking), caches it on disk under `hass.config.path('.storage/ipixel_emoji_cache')`, composes it onto a canvas matching the device dimensions with PIL, returns PNG bytes.
- **`api.py`** — new `iPIXELAPI.display_emoji(emoji, bg_color, width_override, height_override)` method. Reuses the existing `make_image_command` + Bluetooth send chain.
- **`__init__.py`** — registers the service once on the first config entry's setup. Resolves the target device via the standard `target: device:` selector, with auto-pick when only one device is configured.
- **`services.yaml`** — declares the service for the UI service editor (emoji text field, optional bg_color RGB selector, optional width/height overrides).
- **`manifest.json`** — version bump 0.1.0 → 0.2.0.

The `width`/`height` overrides are there because some panels (notably 32×32 units sold as B.K. Light at Action) advertise themselves as 64×16 over Bluetooth and only render correctly when fed 32×32 frames. Default behavior uses the device-reported dimensions, so existing setups are unaffected.

## Example usage

```yaml
- service: ipixel_color.show_emoji
  target:
    device_id: <your iPIXEL device>
  data:
    emoji: "🔔"
```

For a panel that misreports its dimensions:

```yaml
- service: ipixel_color.show_emoji
  data:
    emoji: "🐱"
    width: 32
    height: 32
```

## Testing

Tested live on a 32×32 B.K. Light (Action). 🔔 ⚠️ 🔥 🚨 ❤️ 🐱 ⬇️ all render correctly with the `width: 32, height: 32` overrides. Cache works (no re-download on repeat calls).

## Disclosure

I'm not a developer — I described the use case, tested every step on my hardware, and validated each change. The actual code was written with [Claude Code](https://claude.com/claude-code)'s help based on my requirements and feedback. I'm happy to iterate on any review comments.

## Related issues

May also help with #33 (Textimage not working) for users with the dimension mismatch, though that's likely a separate root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)