### PR TITLE
Add options flow to override firmware-reported panel dimensions

### DIFF
--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Setting up iPIXEL Color for %s (%s)", name, address)
     
     # Create API instance with hass for Bluetooth proxy support
-    api = iPIXELAPI(hass, address)
+    api = iPIXELAPI(hass, address, entry=entry)
     
     # Test connection
     try:
@@ -51,10 +51,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api
     entry.runtime_data = api
-    
+
+    # Reload the entry whenever options change (e.g. dimension overrides)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
+
     return True
 
 

--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -7,6 +7,7 @@ from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.config_entries import ConfigEntry
 
 from .bluetooth.client import BluetoothClient
 from .device.commands import (
@@ -19,6 +20,7 @@ from .device.image import make_image_command
 from .device.info import build_device_info_command, parse_device_response
 from .display.text_renderer import render_text_to_png
 from .exceptions import iPIXELConnectionError
+from .const import OPT_OVERRIDE_DIMENSIONS, OPT_PANEL_WIDTH, OPT_PANEL_HEIGHT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,18 +28,36 @@ _LOGGER = logging.getLogger(__name__)
 class iPIXELAPI:
     """iPIXEL Color device API client - simplified facade."""
 
-    def __init__(self, hass: HomeAssistant, address: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        entry: "ConfigEntry | None" = None,
+    ) -> None:
         """Initialize the API client.
 
         Args:
             hass: Home Assistant instance
             address: Bluetooth MAC address
+            entry: Config entry holding integration options (dimension overrides, etc.)
         """
         self._address = address
+        self._entry = entry
         self._bluetooth = BluetoothClient(hass, address)
         self._power_state = False
         self._device_info: dict[str, Any] | None = None
         self._device_response: bytes | None = None
+
+    def _resolved_dimensions(self, base_info: dict[str, Any]) -> tuple[int, int]:
+        """Return (width, height) honoring options-flow overrides if set."""
+        if self._entry is None:
+            return base_info["width"], base_info["height"]
+        options = self._entry.options
+        if not options.get(OPT_OVERRIDE_DIMENSIONS):
+            return base_info["width"], base_info["height"]
+        width = options.get(OPT_PANEL_WIDTH) or base_info["width"]
+        height = options.get(OPT_PANEL_HEIGHT) or base_info["height"]
+        return width, height
         
     async def connect(self) -> bool:
         """Connect to the iPIXEL device."""
@@ -222,10 +242,10 @@ class iPIXELAPI:
             bg_color: Background color in hex format (e.g., '000000')
         """
         try:
-            # Get device dimensions
-            device_info = await self.get_device_info()
-            width = device_info["width"]
-            height = device_info["height"]
+            # Get device dimensions (honors options-flow override if set)
+            base_info = await self.get_device_info()
+            width, height = self._resolved_dimensions(base_info)
+            device_info = {**base_info, "width": width, "height": height}
 
             # Render text to PNG with color gradient
             png_data = render_text_to_png(text, width, height, antialias, font_size, font, line_spacing, text_color, bg_color)
@@ -290,9 +310,9 @@ class iPIXELAPI:
             True if text was sent successfully
         """
         try:
-            # Get device info for height
-            device_info = await self.get_device_info()
-            device_height = device_info["height"]
+            # Get device info for height (honors options-flow override if set)
+            base_info = await self.get_device_info()
+            _, device_height = self._resolved_dimensions(base_info)
 
             # Generate text commands using pypixelcolor
             commands = make_text_command(

--- a/custom_components/ipixel_color/config_flow.py
+++ b/custom_components/ipixel_color/config_flow.py
@@ -13,7 +13,13 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .api import iPIXELAPI, iPIXELConnectionError, iPIXELTimeoutError
 from .bluetooth.scanner import discover_ipixel_devices_ha
-from .const import DOMAIN, CONF_ADDRESS
+from .const import (
+    DOMAIN,
+    CONF_ADDRESS,
+    OPT_OVERRIDE_DIMENSIONS,
+    OPT_PANEL_WIDTH,
+    OPT_PANEL_HEIGHT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,6 +70,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self):
         """Initialize config flow."""
         self._discovered_devices: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -274,4 +287,44 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="bluetooth_confirm",
             description_placeholders=placeholders,
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle an options flow for iPIXEL Color.
+
+    NOTE: do NOT define __init__(self, config_entry) and assign to
+    self.config_entry — on modern HA (2024.12+), `config_entry` is a
+    read-only property automatically populated by the framework, so
+    overriding it raises ``AttributeError: ... has no setter``.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    OPT_OVERRIDE_DIMENSIONS,
+                    default=current.get(OPT_OVERRIDE_DIMENSIONS, False),
+                ): bool,
+                vol.Optional(
+                    OPT_PANEL_WIDTH,
+                    default=current.get(OPT_PANEL_WIDTH, 0),
+                ): vol.All(int, vol.Range(min=0, max=512)),
+                vol.Optional(
+                    OPT_PANEL_HEIGHT,
+                    default=current.get(OPT_PANEL_HEIGHT, 0),
+                ): vol.All(int, vol.Range(min=0, max=512)),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=schema,
         )

--- a/custom_components/ipixel_color/const.py
+++ b/custom_components/ipixel_color/const.py
@@ -15,6 +15,15 @@ DEVICE_NAME_PREFIX = "LED_BLE_"
 CONF_ADDRESS = "address"
 CONF_NAME = "name"
 
+# Options keys (configurable via the integration's options flow)
+# Override the dimensions reported by firmware. Some panels (notably the
+# B.K. Light 32x32 sold at Action) advertise wrong dimensions (64x16) and
+# only render correctly when the host sends frames at the actual size.
+# 0 means "use firmware-reported value".
+OPT_OVERRIDE_DIMENSIONS = "override_dimensions"
+OPT_PANEL_WIDTH = "panel_width"
+OPT_PANEL_HEIGHT = "panel_height"
+
 # Update interval
 SCAN_INTERVAL = 30
 

--- a/custom_components/ipixel_color/manifest.json
+++ b/custom_components/ipixel_color/manifest.json
@@ -29,5 +29,5 @@
     "pillow>=10.0.0",
     "pypixelcolor>=0.4.0"
   ],
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/custom_components/ipixel_color/strings.json
+++ b/custom_components/ipixel_color/strings.json
@@ -38,6 +38,19 @@
       "unknown": "Unknown error occurred."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "iPIXEL Color options",
+        "description": "Some panels (e.g. the 32x32 B.K. Light sold at Action) advertise wrong dimensions over Bluetooth. Enable the override and provide the actual physical dimensions if your panel renders incorrectly.",
+        "data": {
+          "override_dimensions": "Override panel dimensions",
+          "panel_width": "Panel width (pixels, 0 = use firmware-reported)",
+          "panel_height": "Panel height (pixels, 0 = use firmware-reported)"
+        }
+      }
+    }
+  },
   "entity": {
     "switch": {
       "power": {

--- a/custom_components/ipixel_color/translations/en.json
+++ b/custom_components/ipixel_color/translations/en.json
@@ -38,6 +38,19 @@
       "unknown": "Unknown error occurred."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "iPIXEL Color options",
+        "description": "Some panels (e.g. the 32x32 B.K. Light sold at Action) advertise wrong dimensions over Bluetooth. Enable the override and provide the actual physical dimensions if your panel renders incorrectly.",
+        "data": {
+          "override_dimensions": "Override panel dimensions",
+          "panel_width": "Panel width (pixels, 0 = use firmware-reported)",
+          "panel_height": "Panel height (pixels, 0 = use firmware-reported)"
+        }
+      }
+    }
+  },
   "entity": {
     "switch": {
       "power": {

--- a/custom_components/ipixel_color/translations/fr.json
+++ b/custom_components/ipixel_color/translations/fr.json
@@ -1,0 +1,15 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options iPIXEL Color",
+        "description": "Certains panneaux (ex : le B.K. Light 32x32 vendu chez Action) annoncent de mauvaises dimensions par Bluetooth. Active l'override et indique les dimensions physiques réelles si l'affichage est incorrect.",
+        "data": {
+          "override_dimensions": "Forcer les dimensions du panneau",
+          "panel_width": "Largeur du panneau (pixels, 0 = valeur du firmware)",
+          "panel_height": "Hauteur du panneau (pixels, 0 = valeur du firmware)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an integration-level options flow that lets users override the panel dimensions reported by the firmware over Bluetooth. Some panels lie:

- The **B.K. Light 32×32** sold at Action advertises itself as **64×16** through the device-info characteristic.
- The integration currently trusts the firmware value and sends frames at 64×16, which renders as a black or garbled half-screen on the actual 32×32 LEDs.

I confirmed this on my own hardware by counting LEDs on a row.

## What it does

New options page reachable at **Settings → Devices & Services → iPIXEL Color → ⋮ Configure**:

| Field | Type | Default | Effect |
|---|---|---|---|
| Override panel dimensions | bool | `false` | Master switch — when off, behavior is unchanged |
| Panel width | int (0–512) | `0` | `0` falls back to firmware-reported value |
| Panel height | int (0–512) | `0` | `0` falls back to firmware-reported value |

**Behavior:**
- Default (override off) → dimensions come from `get_device_info()`. Existing setups see no behavior change.
- Override on → configured dimensions are used by both `display_text` (PIL → `make_image_command`) and `display_text_pypixelcolor` (`make_text_command`'s `char_height`).
- Saving the form triggers an entry reload via `add_update_listener`, so values take effect without a Home Assistant restart.

## Implementation notes

- `const.py` adds the three option keys.
- `config_flow.py` registers the static `async_get_options_flow` and exposes `OptionsFlowHandler`. **Important:** in modern HA (2024.12+), `OptionsFlow.config_entry` is a read-only property automatically populated by the framework. Defining `__init__(self, config_entry)` and assigning `self.config_entry` raises `AttributeError: ... has no setter`. So the handler intentionally has no `__init__` — see the comment in the code.
- `__init__.py` passes the config entry to `iPIXELAPI` and wires `entry.add_update_listener(async_reload_entry)` on top of `entry.async_on_unload`.
- `api.py` accepts an optional `entry` kwarg in `iPIXELAPI.__init__` (default `None` for backward compatibility) and uses a small helper `_resolved_dimensions(base_info)` to centralize the lookup.
- Strings/translations cover the form labels in EN and FR.

## Testing

Tested live on a 32×32 B.K. Light (Action) running my own iPIXEL setup:

- Default behavior with override off → identical to before this PR.
- Override on with `32 × 32` → text mode (pypixelcolor) renders at full height; textimage mode (PIL) fills the screen properly; multi-line `\n` works.
- Saving the option reloads the entry and the new dimensions take effect immediately, no HA restart needed.

## Relation to PR #37

I have a separate, independent PR **#37** that adds an `ipixel_color.show_emoji` service. The two PRs are deliberately decoupled:

- **#37** carries per-call `width` / `height` service parameters as a per-invocation override scoped to emoji rendering.
- **This PR** sets a config-level override that applies to all display methods.

Both can be merged in either order. Whichever is merged second will need a small rebase on `api.py` and `__init__.py` (a few minutes of conflict resolution). Once both are merged, `display_emoji` could be wired to fall back to `_resolved_dimensions` so that users only need to configure their dimensions once — but I deliberately kept that out of this PR to keep it focused.

## Disclosure

I'm not a developer — I described the use case, tested every step on my hardware, and validated each change. The actual code was written with [Claude Code](https://claude.com/claude-code)'s help based on my requirements and feedback. I'm happy to iterate on any review comments.

## Related

- Likely root cause behind issue #33 ("Textimage not working") for users with the same dimension mismatch.
- Same Action panel referenced in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)