### PR TITLE
[codex] Add 96x16 weather clock display support

### DIFF
--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -2,14 +2,26 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
+
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from .api import iPIXELAPI, iPIXELConnectionError, iPIXELTimeoutError
-from .const import DOMAIN, CONF_ADDRESS, CONF_NAME
+from .const import (
+    CONF_DISPLAY_HEIGHT,
+    CONF_DISPLAY_WIDTH,
+    DOMAIN,
+    CONF_ADDRESS,
+    CONF_NAME,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,6 +29,19 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.TEXT, Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.LIGHT]
 
 # Type alias for iPIXEL config entries
+SERVICE_DISPLAY_WEATHER_CLOCK = "display_weather_clock"
+
+DISPLAY_WEATHER_CLOCK_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entity_id"): vol.Any(str, [str]),
+        vol.Optional("device_id"): vol.Any(str, [str]),
+        vol.Optional("area_id"): vol.Any(str, [str]),
+        vol.Optional("weather_entity", default="weather.forecast_home"): str,
+        vol.Optional("font_name", default="7x5.ttf"): str,
+        vol.Optional("font_size", default=7.5): vol.Coerce(float),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -27,7 +52,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Setting up iPIXEL Color for %s (%s)", name, address)
     
     # Create API instance with hass for Bluetooth proxy support
-    api = iPIXELAPI(hass, address)
+    display_width = entry.options.get(
+        CONF_DISPLAY_WIDTH,
+        entry.data.get(CONF_DISPLAY_WIDTH),
+    )
+    display_height = entry.options.get(
+        CONF_DISPLAY_HEIGHT,
+        entry.data.get(CONF_DISPLAY_HEIGHT),
+    )
+    api = iPIXELAPI(
+        hass,
+        address,
+        display_width=display_width,
+        display_height=display_height,
+    )
     
     # Test connection
     try:
@@ -51,6 +89,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = api
     entry.runtime_data = api
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+    _register_services(hass)
     
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -79,3 +119,86 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await async_reload_entry(hass, entry)
+
+
+def _register_services(hass: HomeAssistant) -> None:
+    """Register integration services once."""
+    if hass.services.has_service(DOMAIN, SERVICE_DISPLAY_WEATHER_CLOCK):
+        return
+
+    async def async_display_weather_clock(call: ServiceCall) -> None:
+        """Render and display the custom weather clock layout."""
+        api = _get_api_for_service_call(hass, call.data)
+        weather_entity = call.data["weather_entity"]
+        weather_state = hass.states.get(weather_entity)
+        if weather_state is None:
+            _LOGGER.error("Weather entity not found: %s", weather_entity)
+            return
+
+        temperature = weather_state.attributes.get("temperature")
+        now = dt_util.now()
+
+        if not api.is_connected:
+            _LOGGER.debug("Reconnecting to device for weather clock update")
+            await api.connect()
+
+        success = await api.display_weather_clock(
+            condition=weather_state.state,
+            temperature=temperature,
+            hour_minute=now.strftime("%H:%M"),
+            weekday_index=now.weekday(),
+            day=now.day,
+            month=now.month,
+            font_name=call.data["font_name"],
+            font_size=call.data["font_size"],
+        )
+        if not success:
+            _LOGGER.error("Weather clock service failed")
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DISPLAY_WEATHER_CLOCK,
+        async_display_weather_clock,
+        schema=DISPLAY_WEATHER_CLOCK_SCHEMA,
+    )
+
+
+def _get_api_for_service_call(
+    hass: HomeAssistant,
+    data: dict[str, Any],
+) -> iPIXELAPI:
+    """Resolve API instance from service target data."""
+    entity_ids = data.get("entity_id")
+    if isinstance(entity_ids, str):
+        entity_ids = [entity_ids]
+
+    if entity_ids:
+        registry = er.async_get(hass)
+        entry = registry.entities.get(entity_ids[0])
+        if entry and entry.config_entry_id in hass.data.get(DOMAIN, {}):
+            return hass.data[DOMAIN][entry.config_entry_id]
+        raise ValueError(f"Could not resolve iPIXEL entity: {entity_ids[0]}")
+
+    device_ids = data.get("device_id")
+    if isinstance(device_ids, str):
+        device_ids = [device_ids]
+
+    if device_ids:
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get(device_ids[0])
+        if device:
+            for config_entry_id in device.config_entries:
+                if config_entry_id in hass.data.get(DOMAIN, {}):
+                    return hass.data[DOMAIN][config_entry_id]
+        raise ValueError(f"Could not resolve iPIXEL device: {device_ids[0]}")
+
+    apis = list(hass.data.get(DOMAIN, {}).values())
+    if len(apis) == 1:
+        return apis[0]
+
+    raise ValueError("Specify entity_id when multiple iPIXEL devices are configured")

--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -44,6 +44,12 @@ DISPLAY_WEATHER_CLOCK_SCHEMA = vol.Schema(
 )
 
 
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
+    """Set up iPIXEL Color services."""
+    _register_services(hass)
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up iPIXEL Color from a config entry."""
     address = entry.data[CONF_ADDRESS]

--- a/custom_components/ipixel_color/__init__.py
+++ b/custom_components/ipixel_color/__init__.py
@@ -26,10 +26,33 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 # Platforms supported by this integration
-PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.TEXT, Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.BUTTON, Platform.LIGHT]
+PLATFORMS: list[Platform] = [
+    Platform.SWITCH,
+    Platform.TEXT,
+    Platform.SENSOR,
+    Platform.NUMBER,
+]
 
 # Type alias for iPIXEL config entries
 SERVICE_DISPLAY_WEATHER_CLOCK = "display_weather_clock"
+LEGACY_CONTROL_SUFFIXES = {
+    "antialiasing",
+    "auto_update",
+    "clock_24h",
+    "clock_show_date",
+    "font_select",
+    "mode_select",
+    "clock_style_select",
+    "font_size",
+    "line_spacing",
+    "text_animation",
+    "text_speed",
+    "text_rainbow",
+    "update_button",
+    "sync_time_button",
+    "text_color",
+    "background_color",
+}
 
 DISPLAY_WEATHER_CLOCK_SCHEMA = vol.Schema(
     {
@@ -37,6 +60,7 @@ DISPLAY_WEATHER_CLOCK_SCHEMA = vol.Schema(
         vol.Optional("device_id"): vol.Any(str, [str]),
         vol.Optional("area_id"): vol.Any(str, [str]),
         vol.Optional("weather_entity", default="weather.forecast_home"): str,
+        vol.Optional("custom_text"): str,
         vol.Optional("font_name", default="7x5.ttf"): str,
         vol.Optional("font_size", default=7.5): vol.Coerce(float),
     },
@@ -97,6 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.runtime_data = api
     entry.async_on_unload(entry.add_update_listener(async_update_options))
     _register_services(hass)
+    _remove_legacy_control_entities(hass, address)
     
     # Set up platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -147,6 +172,9 @@ def _register_services(hass: HomeAssistant) -> None:
             return
 
         temperature = weather_state.attributes.get("temperature")
+        custom_text = call.data.get("custom_text")
+        if custom_text is None:
+            custom_text = _get_custom_text(hass, api.address)
         now = dt_util.now()
 
         if not api.is_connected:
@@ -160,6 +188,7 @@ def _register_services(hass: HomeAssistant) -> None:
             weekday_index=now.weekday(),
             day=now.day,
             month=now.month,
+            custom_text=custom_text,
             font_name=call.data["font_name"],
             font_size=call.data["font_size"],
         )
@@ -172,6 +201,30 @@ def _register_services(hass: HomeAssistant) -> None:
         async_display_weather_clock,
         schema=DISPLAY_WEATHER_CLOCK_SCHEMA,
     )
+
+
+def _remove_legacy_control_entities(hass: HomeAssistant, address: str) -> None:
+    """Remove old advanced controls from the entity registry."""
+    registry = er.async_get(hass)
+    for suffix in LEGACY_CONTROL_SUFFIXES:
+        unique_id = f"{address}_{suffix}"
+        for entity_id, entry in list(registry.entities.items()):
+            if entry.platform == DOMAIN and entry.unique_id == unique_id:
+                registry.async_remove(entity_id)
+                _LOGGER.debug("Removed legacy iPIXEL control entity: %s", entity_id)
+
+
+def _get_custom_text(hass: HomeAssistant, address: str) -> str | None:
+    """Read the custom weather-clock text entity."""
+    registry = er.async_get(hass)
+    unique_id = f"{address}_text_display"
+    for entity_id, entry in registry.entities.items():
+        if entry.platform == DOMAIN and entry.unique_id == unique_id:
+            state = hass.states.get(entity_id)
+            if state and state.state not in ("unknown", "unavailable", ""):
+                return state.state
+            return None
+    return None
 
 
 def _get_api_for_service_call(

--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -486,6 +486,7 @@ class iPIXELAPI:
         weekday_index: int,
         day: int,
         month: int,
+        custom_text: str | None = None,
         font_name: str = "7x5.ttf",
         font_size: float = 7.5,
     ) -> bool:
@@ -518,6 +519,7 @@ class iPIXELAPI:
                 weekday_index=weekday_index,
                 day=day,
                 month=month,
+                custom_text=custom_text,
                 font_name=font_name,
                 font_size=font_size,
             )

--- a/custom_components/ipixel_color/api.py
+++ b/custom_components/ipixel_color/api.py
@@ -17,8 +17,17 @@ from .device.clock import make_clock_mode_command, make_time_command
 from .device.text import make_text_command
 from .device.image import make_image_command
 from .device.info import build_device_info_command, parse_device_response
-from .display.text_renderer import render_text_to_png
+from .display.text_renderer import inspect_png, render_text_to_png
+from .display.weather_clock_renderer import render_weather_clock_to_png
 from .exceptions import iPIXELConnectionError
+from .const import (
+    DEFAULT_DISPLAY_HEIGHT,
+    DEFAULT_DISPLAY_WIDTH,
+    DISPLAY_SIZE_TO_LED_TYPE,
+    LED_TYPE_SPECS,
+    NOTIFY_UUID,
+    WRITE_UUID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,18 +35,35 @@ _LOGGER = logging.getLogger(__name__)
 class iPIXELAPI:
     """iPIXEL Color device API client - simplified facade."""
 
-    def __init__(self, hass: HomeAssistant, address: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        display_width: int | None = None,
+        display_height: int | None = None,
+    ) -> None:
         """Initialize the API client.
 
         Args:
             hass: Home Assistant instance
             address: Bluetooth MAC address
+            display_width: Optional manual display width override
+            display_height: Optional manual display height override
         """
         self._address = address
         self._bluetooth = BluetoothClient(hass, address)
         self._power_state = False
         self._device_info: dict[str, Any] | None = None
         self._device_response: bytes | None = None
+        self._display_width_override = self._normalize_dimension(display_width)
+        self._display_height_override = self._normalize_dimension(display_height)
+        if self._display_width_override and self._display_height_override:
+            _LOGGER.info(
+                "Configured display size override for %s: %dx%d",
+                self._address,
+                self._display_width_override,
+                self._display_height_override,
+            )
         
     async def connect(self) -> bool:
         """Connect to the iPIXEL device."""
@@ -157,6 +183,9 @@ class iPIXELAPI:
             
         try:
             command = build_device_info_command()
+            client = self._bluetooth._client
+            if client is None:
+                raise iPIXELConnectionError("Device not connected")
             
             # Set up notification response
             self._device_response = None
@@ -166,50 +195,84 @@ class iPIXELAPI:
                 self._device_response = bytes(data)
                 response_received.set()
             
-            # Enable notifications temporarily
-            await self._bluetooth._client.start_notify(
-                "0000fa03-0000-1000-8000-00805f9b34fb", response_handler
-            )
+            try:
+                await client.stop_notify(NOTIFY_UUID)
+            except Exception as err:
+                _LOGGER.debug("Device info notify stop skipped: %s", err)
             
             try:
-                # Send command
-                await self._bluetooth._client.write_gatt_char(
-                    "0000fa02-0000-1000-8000-00805f9b34fb", command
+                await client.start_notify(NOTIFY_UUID, response_handler)
+                _LOGGER.debug(
+                    "Requesting device info via %s (%d bytes)",
+                    WRITE_UUID,
+                    len(command),
                 )
+                await client.write_gatt_char(WRITE_UUID, command)
+                _LOGGER.debug("Device info request write succeeded via %s", WRITE_UUID)
                 
                 # Wait for response (5 second timeout)
                 await asyncio.wait_for(response_received.wait(), timeout=5.0)
                 
                 if self._device_response:
-                    self._device_info = parse_device_response(self._device_response)
+                    self._device_info = self._apply_display_overrides(
+                        parse_device_response(self._device_response),
+                        "device response",
+                    )
                 else:
                     raise Exception("No response received")
                     
             finally:
-                await self._bluetooth._client.stop_notify(
-                    "0000fa03-0000-1000-8000-00805f9b34fb"
-                )
+                try:
+                    await client.stop_notify(NOTIFY_UUID)
+                except Exception as err:
+                    _LOGGER.debug("Device info notify cleanup skipped: %s", err)
+
+                if self._bluetooth._notification_handler:
+                    try:
+                        await client.start_notify(
+                            NOTIFY_UUID,
+                            self._bluetooth._notification_handler,
+                        )
+                    except Exception as err:
+                        _LOGGER.warning("Could not restore notification handler: %s", err)
             
-            _LOGGER.info("Device info retrieved: %s", self._device_info)
+            _LOGGER.info(
+                "Device info retrieved: type=%s led_type=%s size=%dx%d mcu=%s wifi=%s",
+                self._device_info.get("device_type_str"),
+                self._device_info.get("led_type"),
+                self._device_info.get("width"),
+                self._device_info.get("height"),
+                self._device_info.get("mcu_version"),
+                self._device_info.get("wifi_version"),
+            )
             return self._device_info
             
         except Exception as err:
             _LOGGER.error("Failed to get device info: %s", err)
             # Return default values
-            self._device_info = {
-                "width": 64,
-                "height": 16,
-                "device_type": 0,
-                "device_type_str": "Unknown",
-                "led_type": 0,
-                "mcu_version": "Unknown",
-                "wifi_version": "Unknown",
-                "has_wifi": False,
-                "password_flag": 255
-            }
+            self._device_info = self._apply_display_overrides(
+                self._build_default_device_info(),
+                "fallback",
+            )
+            _LOGGER.warning(
+                "Using device info fallback: type=%s led_type=%s size=%dx%d",
+                self._device_info.get("device_type_str"),
+                self._device_info.get("led_type"),
+                self._device_info.get("width"),
+                self._device_info.get("height"),
+            )
             return self._device_info
     
-    async def display_text(self, text: str, antialias: bool = True, font_size: float | None = None, font: str | None = None, line_spacing: int = 0, text_color: str = "ffffff", bg_color: str = "000000") -> bool:
+    async def display_text(
+        self,
+        text: str,
+        antialias: bool = True,
+        font_size: float | None = None,
+        font: str | None = None,
+        line_spacing: int = 0,
+        text_color: str = "ffffff",
+        bg_color: str = "000000",
+    ) -> bool:
         """Display text as image using PIL and pypixelcolor with color gradient mapping.
 
         Args:
@@ -226,9 +289,64 @@ class iPIXELAPI:
             device_info = await self.get_device_info()
             width = device_info["width"]
             height = device_info["height"]
+            expected_pixels = width * height
+
+            _LOGGER.debug(
+                "Textimage render settings: type=%s led_type=%s size=%dx%d "
+                "font=%s font_size=%s line_spacing=%d antialias=%s "
+                "text_color=#%s bg_color=#%s",
+                device_info.get("device_type_str"),
+                device_info.get("led_type"),
+                width,
+                height,
+                font or "OpenSans-Light.ttf",
+                f"{font_size:.1f}" if font_size else "auto",
+                line_spacing,
+                antialias,
+                text_color,
+                bg_color,
+            )
 
             # Render text to PNG with color gradient
-            png_data = render_text_to_png(text, width, height, antialias, font_size, font, line_spacing, text_color, bg_color)
+            png_data = render_text_to_png(
+                text,
+                width,
+                height,
+                antialias,
+                font_size,
+                font,
+                line_spacing,
+                text_color,
+                bg_color,
+            )
+            rendered_width, rendered_height, raw_rgb_length = inspect_png(png_data)
+
+            if (rendered_width, rendered_height) != (width, height):
+                _LOGGER.error(
+                    "Rendered image size mismatch: expected %dx%d, got %dx%d",
+                    width,
+                    height,
+                    rendered_width,
+                    rendered_height,
+                )
+                return False
+
+            if rendered_width * rendered_height != expected_pixels:
+                _LOGGER.error(
+                    "Rendered image pixel count mismatch: expected %d, got %d",
+                    expected_pixels,
+                    rendered_width * rendered_height,
+                )
+                return False
+
+            _LOGGER.debug(
+                "Rendered textimage: size=%dx%d pixels=%d raw_rgb_payload=%d png_payload=%d",
+                rendered_width,
+                rendered_height,
+                expected_pixels,
+                raw_rgb_length,
+                len(png_data),
+            )
 
             # Generate image commands using pypixelcolor
             commands = make_image_command(
@@ -236,6 +354,18 @@ class iPIXELAPI:
                 file_extension=".png",
                 resize_method="crop",
                 device_info_dict=device_info
+            )
+
+            if not commands:
+                _LOGGER.error("No BLE image frames generated; aborting textimage upload")
+                return False
+
+            total_command_bytes = sum(len(command) for command in commands)
+            _LOGGER.debug(
+                "Generated textimage BLE payload: frames=%d total_bytes=%d write_char=%s",
+                len(commands),
+                total_command_bytes,
+                WRITE_UUID,
             )
 
             # Send all command frames
@@ -248,8 +378,19 @@ class iPIXELAPI:
                 )
                 success = await self._bluetooth.send_command(command)
                 if not success:
-                    _LOGGER.error("Failed to send image frame %d/%d", i + 1, len(commands))
+                    _LOGGER.error(
+                        "Failed to send image frame %d/%d via %s",
+                        i + 1,
+                        len(commands),
+                        WRITE_UUID,
+                    )
                     return False
+                _LOGGER.debug(
+                    "Image frame %d/%d write succeeded via %s",
+                    i + 1,
+                    len(commands),
+                    WRITE_UUID,
+                )
 
             _LOGGER.info(
                 "Text rendered as image: '%s' (%dx%d, %d bytes PNG, %d frames)",
@@ -336,9 +477,190 @@ class iPIXELAPI:
             _LOGGER.error("Error displaying pypixelcolor text: %s", err)
             return False
 
+    async def display_weather_clock(
+        self,
+        *,
+        condition: str,
+        temperature: float | int | None,
+        hour_minute: str,
+        weekday_index: int,
+        day: int,
+        month: int,
+        font_name: str = "7x5.ttf",
+        font_size: float = 7.5,
+    ) -> bool:
+        """Display the custom 96x16 weather clock bitmap layout."""
+        try:
+            device_info = await self.get_device_info()
+            width = device_info["width"]
+            height = device_info["height"]
+
+            _LOGGER.debug(
+                "Weather clock render settings: condition=%s temp=%s time=%s "
+                "date=%d/%d size=%dx%d font=%s font_size=%.1f",
+                condition,
+                temperature,
+                hour_minute,
+                day,
+                month,
+                width,
+                height,
+                font_name,
+                font_size,
+            )
+
+            png_data = render_weather_clock_to_png(
+                width=width,
+                height=height,
+                condition=condition,
+                temperature=temperature,
+                hour_minute=hour_minute,
+                weekday_index=weekday_index,
+                day=day,
+                month=month,
+                font_name=font_name,
+                font_size=font_size,
+            )
+            rendered_width, rendered_height, raw_rgb_length = inspect_png(png_data)
+            expected_pixels = width * height
+
+            if (rendered_width, rendered_height) != (width, height):
+                _LOGGER.error(
+                    "Weather clock image size mismatch: expected %dx%d, got %dx%d",
+                    width,
+                    height,
+                    rendered_width,
+                    rendered_height,
+                )
+                return False
+
+            if raw_rgb_length != expected_pixels * 3:
+                _LOGGER.error(
+                    "Weather clock payload mismatch: expected %d RGB bytes, got %d",
+                    expected_pixels * 3,
+                    raw_rgb_length,
+                )
+                return False
+
+            commands = make_image_command(
+                image_bytes=png_data,
+                file_extension=".png",
+                resize_method="crop",
+                device_info_dict=device_info,
+            )
+
+            if not commands:
+                _LOGGER.error("No BLE image frames generated for weather clock")
+                return False
+
+            _LOGGER.debug(
+                "Generated weather clock BLE payload: frames=%d total_bytes=%d "
+                "write_char=%s",
+                len(commands),
+                sum(len(command) for command in commands),
+                WRITE_UUID,
+            )
+
+            for i, command in enumerate(commands):
+                success = await self._bluetooth.send_command(command)
+                if not success:
+                    _LOGGER.error(
+                        "Failed to send weather clock frame %d/%d via %s",
+                        i + 1,
+                        len(commands),
+                        WRITE_UUID,
+                    )
+                    return False
+
+            _LOGGER.info(
+                "Weather clock displayed: %s %s %dx%d",
+                condition,
+                temperature,
+                width,
+                height,
+            )
+            return True
+
+        except Exception as err:
+            _LOGGER.error("Error displaying weather clock: %s", err)
+            return False
+
     def _notification_handler(self, sender: Any, data: bytearray) -> None:
         """Handle notifications from the device."""
         _LOGGER.debug("Notification from %s: %s", sender, data.hex())
+
+    @staticmethod
+    def _normalize_dimension(value: int | str | None) -> int | None:
+        """Normalize a display dimension override."""
+        try:
+            dimension = int(value) if value is not None else 0
+        except (TypeError, ValueError):
+            return None
+        return dimension if dimension > 0 else None
+
+    def _build_default_device_info(self) -> dict[str, Any]:
+        """Build default device info for devices that do not answer info queries."""
+        return {
+            "width": DEFAULT_DISPLAY_WIDTH,
+            "height": DEFAULT_DISPLAY_HEIGHT,
+            "device_type": 131,
+            "device_type_str": "Unknown",
+            "led_type": 3,
+            "mcu_version": "Unknown",
+            "wifi_version": "Unknown",
+            "has_wifi": False,
+            "password_flag": 255,
+        }
+
+    def _apply_display_overrides(
+        self,
+        device_info: dict[str, Any],
+        source: str,
+    ) -> dict[str, Any]:
+        """Apply configured display size overrides to device info."""
+        info = dict(device_info)
+        width = self._display_width_override
+        height = self._display_height_override
+
+        if bool(width) != bool(height):
+            _LOGGER.warning(
+                "Ignoring incomplete display size override width=%s height=%s",
+                width,
+                height,
+            )
+            return info
+
+        if not width or not height:
+            _LOGGER.debug(
+                "Detected display from %s: type=%s led_type=%s size=%dx%d",
+                source,
+                info.get("device_type_str"),
+                info.get("led_type"),
+                info.get("width"),
+                info.get("height"),
+            )
+            return info
+
+        led_type = DISPLAY_SIZE_TO_LED_TYPE.get((width, height))
+        if led_type is not None:
+            spec = LED_TYPE_SPECS[led_type]
+            info["device_type"] = spec["device_type"]
+            info["led_type"] = led_type
+            info["device_type_str"] = f"Type {led_type} ({spec['name']}, override)"
+        else:
+            info["device_type_str"] = f"Unknown ({width}x{height}, override)"
+
+        info["width"] = width
+        info["height"] = height
+        _LOGGER.info(
+            "Applied display size override to %s: type=%s led_type=%s size=%dx%d",
+            source,
+            info.get("device_type_str"),
+            info.get("led_type"),
+            width,
+            height,
+        )
+        return info
     
     @property
     def is_connected(self) -> bool:

--- a/custom_components/ipixel_color/bluetooth/client.py
+++ b/custom_components/ipixel_color/bluetooth/client.py
@@ -144,8 +144,18 @@ class BluetoothClient:
             await self._client.start_notify(NOTIFY_UUID, response_handler)
 
             try:
-                _LOGGER.debug("Sending command: %s", command.hex())
+                _LOGGER.debug(
+                    "Writing BLE command to %s: %d bytes (%s)",
+                    WRITE_UUID,
+                    len(command),
+                    command.hex(),
+                )
                 await self._client.write_gatt_char(WRITE_UUID, command)
+                _LOGGER.debug(
+                    "BLE write succeeded to %s: %d bytes",
+                    WRITE_UUID,
+                    len(command),
+                )
 
                 # Wait for response with short timeout
                 try:
@@ -172,7 +182,12 @@ class BluetoothClient:
 
             return True
         except BleakError as err:
-            _LOGGER.error("Failed to send command: %s", err)
+            _LOGGER.error(
+                "BLE write failed to %s (%d bytes): %s",
+                WRITE_UUID,
+                len(command),
+                err,
+            )
             return False
 
     @property

--- a/custom_components/ipixel_color/common.py
+++ b/custom_components/ipixel_color/common.py
@@ -118,7 +118,7 @@ async def update_ipixel_display(hass: HomeAssistant, device_name: str, api, text
         if not mode:
             mode = MODE_TEXT_IMAGE  # Default to textimage mode
 
-        _LOGGER.debug("Updating display in mode: %s", mode)
+        _LOGGER.debug("Updating display: selected_mode=%s", mode)
 
         # Route to appropriate mode handler
         if mode == MODE_TEXT_IMAGE:

--- a/custom_components/ipixel_color/config_flow.py
+++ b/custom_components/ipixel_color/config_flow.py
@@ -7,13 +7,20 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .api import iPIXELAPI, iPIXELConnectionError, iPIXELTimeoutError
 from .bluetooth.scanner import discover_ipixel_devices_ha
-from .const import DOMAIN, CONF_ADDRESS
+from .const import (
+    CONF_DISPLAY_HEIGHT,
+    CONF_DISPLAY_WIDTH,
+    DEFAULT_DISPLAY_HEIGHT,
+    DEFAULT_DISPLAY_WIDTH,
+    DOMAIN,
+    CONF_ADDRESS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,6 +67,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for iPIXEL Color."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> iPIXELOptionsFlowHandler:
+        """Create the options flow."""
+        return iPIXELOptionsFlowHandler(config_entry)
 
     def __init__(self):
         """Initialize config flow."""
@@ -191,6 +206,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({
                     vol.Required(CONF_ADDRESS): str,
                     vol.Optional(CONF_NAME, default="iPIXEL Display"): str,
+                    **_display_override_schema(),
                 }),
             )
 
@@ -212,7 +228,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             
             return self.async_create_entry(
                 title=info["title"], 
-                data=user_input
+                data=_clean_display_overrides(user_input)
             )
 
         return self.async_show_form(
@@ -220,6 +236,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({
                 vol.Required(CONF_ADDRESS, default=user_input.get(CONF_ADDRESS, "")): str,
                 vol.Optional(CONF_NAME, default=user_input.get(CONF_NAME, "iPIXEL Display")): str,
+                **_display_override_schema(
+                    user_input.get(CONF_DISPLAY_WIDTH, 0),
+                    user_input.get(CONF_DISPLAY_HEIGHT, 0),
+                ),
             }),
             errors=errors,
         )
@@ -275,3 +295,74 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="bluetooth_confirm",
             description_placeholders=placeholders,
         )
+
+
+class iPIXELOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options for iPIXEL Color."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage display size overrides."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data=_clean_display_overrides(user_input),
+            )
+
+        current_width = self._config_entry.options.get(
+            CONF_DISPLAY_WIDTH,
+            self._config_entry.data.get(CONF_DISPLAY_WIDTH, 0),
+        )
+        current_height = self._config_entry.options.get(
+            CONF_DISPLAY_HEIGHT,
+            self._config_entry.data.get(CONF_DISPLAY_HEIGHT, 0),
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({
+                **_display_override_schema(current_width, current_height),
+            }),
+            description_placeholders={
+                "default_width": str(DEFAULT_DISPLAY_WIDTH),
+                "default_height": str(DEFAULT_DISPLAY_HEIGHT),
+            },
+        )
+
+
+def _display_override_schema(
+    width: int = 0,
+    height: int = 0,
+) -> dict[Any, Any]:
+    """Return schema fields for display size overrides."""
+    return {
+        vol.Optional(CONF_DISPLAY_WIDTH, default=width): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=0, max=512),
+        ),
+        vol.Optional(CONF_DISPLAY_HEIGHT, default=height): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=0, max=128),
+        ),
+    }
+
+
+def _clean_display_overrides(data: dict[str, Any]) -> dict[str, Any]:
+    """Return data with empty display overrides removed."""
+    cleaned = dict(data)
+    width = int(cleaned.get(CONF_DISPLAY_WIDTH) or 0)
+    height = int(cleaned.get(CONF_DISPLAY_HEIGHT) or 0)
+
+    if width > 0 and height > 0:
+        cleaned[CONF_DISPLAY_WIDTH] = width
+        cleaned[CONF_DISPLAY_HEIGHT] = height
+    else:
+        cleaned.pop(CONF_DISPLAY_WIDTH, None)
+        cleaned.pop(CONF_DISPLAY_HEIGHT, None)
+
+    return cleaned

--- a/custom_components/ipixel_color/const.py
+++ b/custom_components/ipixel_color/const.py
@@ -14,6 +14,62 @@ DEVICE_NAME_PREFIX = "LED_BLE_"
 # Configuration keys
 CONF_ADDRESS = "address"
 CONF_NAME = "name"
+CONF_DISPLAY_WIDTH = "display_width"
+CONF_DISPLAY_HEIGHT = "display_height"
+
+DEVICE_TYPE_BYTE_TO_LED_TYPE = {
+    128: 0,
+    129: 2,
+    130: 4,
+    131: 3,
+    132: 1,
+    133: 5,
+    134: 6,
+    135: 7,
+    136: 8,
+    137: 9,
+    138: 10,
+    139: 11,
+    140: 12,
+    141: 13,
+    142: 14,
+    143: 15,
+    144: 16,
+    145: 17,
+    146: 18,
+    147: 19,
+}
+
+LED_TYPE_SPECS = {
+    0: {"width": 64, "height": 64, "device_type": 128, "name": "64x64"},
+    1: {"width": 96, "height": 16, "device_type": 132, "name": "96x16"},
+    2: {"width": 32, "height": 32, "device_type": 129, "name": "32x32"},
+    3: {"width": 64, "height": 16, "device_type": 131, "name": "64x16"},
+    4: {"width": 32, "height": 16, "device_type": 130, "name": "32x16"},
+    5: {"width": 64, "height": 20, "device_type": 133, "name": "64x20"},
+    6: {"width": 128, "height": 32, "device_type": 134, "name": "128x32"},
+    7: {"width": 144, "height": 16, "device_type": 135, "name": "144x16"},
+    8: {"width": 192, "height": 16, "device_type": 136, "name": "192x16"},
+    9: {"width": 48, "height": 24, "device_type": 137, "name": "48x24"},
+    10: {"width": 64, "height": 32, "device_type": 138, "name": "64x32"},
+    11: {"width": 96, "height": 32, "device_type": 139, "name": "96x32"},
+    12: {"width": 128, "height": 32, "device_type": 140, "name": "128x32"},
+    13: {"width": 96, "height": 32, "device_type": 141, "name": "96x32"},
+    14: {"width": 160, "height": 32, "device_type": 142, "name": "160x32"},
+    15: {"width": 192, "height": 32, "device_type": 143, "name": "192x32"},
+    16: {"width": 256, "height": 32, "device_type": 144, "name": "256x32"},
+    17: {"width": 320, "height": 32, "device_type": 145, "name": "320x32"},
+    18: {"width": 384, "height": 32, "device_type": 146, "name": "384x32"},
+    19: {"width": 448, "height": 32, "device_type": 147, "name": "448x32"},
+}
+
+DISPLAY_SIZE_TO_LED_TYPE = {
+    (spec["width"], spec["height"]): led_type
+    for led_type, spec in LED_TYPE_SPECS.items()
+}
+
+DEFAULT_DISPLAY_WIDTH = 64
+DEFAULT_DISPLAY_HEIGHT = 16
 
 # Update interval
 SCAN_INTERVAL = 30

--- a/custom_components/ipixel_color/device/image.py
+++ b/custom_components/ipixel_color/device/image.py
@@ -1,6 +1,7 @@
 """Image display commands using pypixelcolor."""
 from __future__ import annotations
 
+import logging
 from typing import Optional
 
 try:
@@ -9,6 +10,8 @@ try:
 except ImportError:
     send_image_hex = None
     SendPlan = None
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def make_image_command(
@@ -35,6 +38,27 @@ def make_image_command(
     """
     if send_image_hex is None:
         raise ImportError("pypixelcolor library is not installed")
+
+    if device_info_dict is not None:
+        width = int(device_info_dict["width"])
+        height = int(device_info_dict["height"])
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Invalid display dimensions: {width}x{height}")
+        _LOGGER.debug(
+            "Building image command: input_payload=%d bytes target=%dx%d "
+            "pixels=%d device_type=%s led_type=%s",
+            len(image_bytes),
+            width,
+            height,
+            width * height,
+            device_info_dict.get("device_type"),
+            device_info_dict.get("led_type"),
+        )
+    else:
+        _LOGGER.debug(
+            "Building image command without device info: input_payload=%d bytes",
+            len(image_bytes),
+        )
 
     # Convert bytes to hex string for pypixelcolor
     hex_string = image_bytes.hex()
@@ -66,5 +90,11 @@ def make_image_command(
     commands = []
     for window in send_plan.windows:
         commands.append(window.data)
+
+    _LOGGER.debug(
+        "Built image command payload: frames=%d total_bytes=%d",
+        len(commands),
+        sum(len(command) for command in commands),
+    )
 
     return commands

--- a/custom_components/ipixel_color/device/info.py
+++ b/custom_components/ipixel_color/device/info.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from ..const import DEVICE_TYPE_BYTE_TO_LED_TYPE, LED_TYPE_SPECS
+
 try:
     from pypixelcolor.lib.internal_commands import build_get_device_info_command
     from pypixelcolor.lib.device_info import parse_device_info as pypixelcolor_parse_device_info
@@ -51,20 +53,33 @@ def parse_device_response(response: bytes) -> dict[str, Any]:
     # Use pypixelcolor's parser to get DeviceInfo object
     device_info_obj = pypixelcolor_parse_device_info(response)
 
+    led_type = device_info_obj.led_type
+    if led_type is None:
+        led_type = DEVICE_TYPE_BYTE_TO_LED_TYPE.get(device_info_obj.device_type)
+
+    spec = LED_TYPE_SPECS.get(led_type)
+    width = device_info_obj.width
+    height = device_info_obj.height
+    device_type_str = "Unknown"
+    if spec:
+        width = spec["width"]
+        height = spec["height"]
+        device_type_str = f"Type {led_type} ({spec['name']})"
+
     # Convert DeviceInfo object to dict for Home Assistant compatibility
     device_info = {
-        "width": device_info_obj.width,
-        "height": device_info_obj.height,
+        "width": width,
+        "height": height,
         "device_type": device_info_obj.device_type,  # int
-        "device_type_str": f"Type {device_info_obj.device_type}",  # String version for display
-        "led_type": device_info_obj.led_type,
+        "device_type_str": device_type_str,  # String version for display
+        "led_type": led_type,
         "mcu_version": device_info_obj.mcu_version,
         "wifi_version": device_info_obj.wifi_version,
         "has_wifi": device_info_obj.has_wifi,
         "password_flag": device_info_obj.password_flag,
     }
 
-    _LOGGER.info("Parsed device info: %dx%d (Type %d, LED Type %s)",
+    _LOGGER.info("Parsed device info: %dx%d (Device byte %d, LED Type %s)",
                  device_info["width"], device_info["height"],
                  device_info["device_type"], device_info["led_type"])
 

--- a/custom_components/ipixel_color/display/text_renderer.py
+++ b/custom_components/ipixel_color/display/text_renderer.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 
 import io
 import logging
-import os
-from pathlib import Path
-from typing import Any, Tuple
-
 from PIL import Image, ImageDraw, ImageFont
 
-from ..color import hex_to_rgb
 from ..fonts import get_font_path
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,7 +14,17 @@ MIN_FONT_SIZE = 4
 MARGIN_THRESHOLD = 64  # Pixel brightness threshold for margin detection
 
 
-def render_text_to_png(text: str, width: int, height: int, antialias: bool = True, font_size: float | None = None, font: str | None = None, line_spacing: int = 0, text_color: str = "ffffff", bg_color: str = "000000") -> bytes:
+def render_text_to_png(
+    text: str,
+    width: int,
+    height: int,
+    antialias: bool = True,
+    font_size: float | None = None,
+    font: str | None = None,
+    line_spacing: int = 0,
+    text_color: str = "ffffff",
+    bg_color: str = "000000",
+) -> bytes:
     """Render text to PNG image data with color gradient mapping.
 
     Args:
@@ -42,6 +47,19 @@ def render_text_to_png(text: str, width: int, height: int, antialias: bool = Tru
         - 255 (white) → text_color
         - Intermediate values → interpolated colors
     """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"Invalid display dimensions: {width}x{height}")
+
+    _LOGGER.debug(
+        "Rendering textimage canvas=%dx%d font=%s font_size=%s line_spacing=%d antialias=%s",
+        width,
+        height,
+        font or "OpenSans-Light.ttf",
+        f"{font_size:.1f}" if font_size else "auto",
+        line_spacing,
+        antialias,
+    )
+
     # Create image with device dimensions
     # Use 'L' mode (grayscale) for non-antialiased to get sharper pixels
     image_mode = "RGB" if antialias else "1"
@@ -100,7 +118,6 @@ def render_text_to_png(text: str, width: int, height: int, antialias: bool = Tru
         total_height += line_spacing * (len(lines) - 1)
     y_offset = (height - total_height) // 2
 
-    print(line_data)
     # Draw each line with corrected positioning
     current_y = y_offset
     for i, (line, data) in enumerate(zip(lines, line_data)):
@@ -120,8 +137,8 @@ def render_text_to_png(text: str, width: int, height: int, antialias: bool = Tru
     
     # Parse hex colors to RGB tuples using utility function
     try:
-        bg_r, bg_g, bg_b = hex_to_rgb(bg_color)
-        text_r, text_g, text_b = hex_to_rgb(text_color)
+        bg_r, bg_g, bg_b = _hex_to_rgb(bg_color)
+        text_r, text_g, text_b = _hex_to_rgb(text_color)
     except (ValueError, IndexError):
         _LOGGER.error("Invalid color format. Using defaults (white text, black background)")
         bg_r, bg_g, bg_b = 0, 0, 0
@@ -159,7 +176,33 @@ def render_text_to_png(text: str, width: int, height: int, antialias: bool = Tru
     # Convert to PNG bytes
     png_buffer = io.BytesIO()
     rgb_img.save(png_buffer, format='PNG')
+    _LOGGER.debug(
+        "Rendered textimage PNG size=%dx%d payload=%d bytes",
+        width,
+        height,
+        len(png_buffer.getvalue()),
+    )
     return png_buffer.getvalue()
+
+
+def inspect_png(png_data: bytes) -> tuple[int, int, int]:
+    """Return rendered PNG dimensions and raw RGB payload size."""
+    with Image.open(io.BytesIO(png_data)) as image:
+        rgb_image = image.convert("RGB")
+        width, height = rgb_image.size
+        return width, height, len(rgb_image.tobytes())
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert a six-digit hex color to RGB."""
+    normalized = hex_color.lstrip("#")
+    if len(normalized) != 6:
+        raise ValueError(f"Invalid hex color length: {hex_color}")
+    return (
+        int(normalized[0:2], 16),
+        int(normalized[2:4], 16),
+        int(normalized[4:6], 16),
+    )
 
 
 def _calculate_content_bounds(img: Image.Image) -> tuple[int, int, int, int] | None:
@@ -242,11 +285,13 @@ def get_fixed_font(size: float, font_name: str | None = None) -> ImageFont.FreeT
             font_path = get_font_path(font_name)
             if font_path:
                 try:
+                    _LOGGER.debug("Using font file: %s at size %.1f", font_path, size)
                     return ImageFont.truetype(str(font_path), size)
                 except Exception as e:
                     _LOGGER.warning("Could not load custom font %s: %s", font_name, e)
 
         # Use default font if custom font failed or not specified
+        _LOGGER.debug("Using PIL default font at requested size %.1f", size)
         return ImageFont.load_default()
     except Exception as e:
         _LOGGER.warning("Error loading font size %.1f: %s, using default", size, e)
@@ -300,20 +345,23 @@ def get_optimal_font(draw: ImageDraw.Draw, lines: list[str],
     # Try sizes around the theoretical optimal with fine increments
     best_font = None
     best_size = 0.0
-    
-    # Test 3 iterations with refinement
-    test_ranges = [
-        (theoretical_size * 0.7, theoretical_size * 1.3, 2.0),  # Coarse: ±30% with 2.0 step
-        (best_size - 2.0, best_size + 2.0, 0.5),                # Medium: ±2 with 0.5 step  
-        (best_size - 0.5, best_size + 0.5, 0.1),                # Fine: ±0.5 with 0.1 step
-    ]
-    
-    for iteration, (start, end, step) in enumerate(test_ranges):
+
+    for iteration, step in enumerate((2.0, 0.5, 0.1)):
         if iteration > 0 and best_size == 0:
             break  # Skip refinement if no valid size found
+
+        if iteration == 0:
+            start = theoretical_size * 0.7
+            end = theoretical_size * 1.3
+        elif iteration == 1:
+            start = best_size - 2.0
+            end = best_size + 2.0
+        else:
+            start = best_size - 0.5
+            end = best_size + 0.5
             
-        current_start = max(1.0, start if iteration == 0 else start)
-        current_end = min(min(max_height, max_width), end if iteration == 0 else end)
+        current_start = max(1.0, start)
+        current_end = min(min(max_height, max_width), end)
         
         size = current_start
         while size <= current_end:

--- a/custom_components/ipixel_color/display/weather_clock_renderer.py
+++ b/custom_components/ipixel_color/display/weather_clock_renderer.py
@@ -1,0 +1,286 @@
+"""Weather clock bitmap rendering for iPIXEL Color displays."""
+from __future__ import annotations
+
+import io
+import logging
+
+from PIL import Image, ImageDraw, ImageFont
+
+from ..fonts import get_font_path
+
+_LOGGER = logging.getLogger(__name__)
+
+WEEKDAYS_TR = ["PZT", "SAL", "CAR", "PER", "CUM", "CMT", "PAZ"]
+MONTHS_TR = [
+    "OCAK",
+    "SUBAT",
+    "MART",
+    "NISAN",
+    "MAYIS",
+    "HAZ",
+    "TEM",
+    "AGU",
+    "EYL",
+    "EKIM",
+    "KAS",
+    "ARA",
+]
+
+
+def render_weather_clock_to_png(
+    *,
+    width: int,
+    height: int,
+    condition: str,
+    temperature: float | int | None,
+    hour_minute: str,
+    weekday_index: int,
+    day: int,
+    month: int,
+    font_name: str = "7x5.ttf",
+    font_size: float = 7.5,
+    background_color: str = "000000",
+) -> bytes:
+    """Render a 96x16 weather clock layout to PNG bytes."""
+    if width <= 0 or height <= 0:
+        raise ValueError(f"Invalid display dimensions: {width}x{height}")
+
+    image = Image.new("RGB", (width, height), _hex_to_rgb(background_color))
+    draw = ImageDraw.Draw(image)
+    font = _load_font(font_name, font_size)
+
+    icon_width = min(18, width // 4)
+    icon_gap = 2
+    _draw_weather_icon(draw, condition, icon_width)
+
+    text_x = icon_width + icon_gap
+    text_width = width - text_x
+    weekday_text = WEEKDAYS_TR[weekday_index]
+    date_text = f"{day} {MONTHS_TR[month - 1]}"
+    temp_text = _format_temperature_value(temperature)
+
+    _draw_date_row(
+        draw,
+        weekday_text,
+        date_text,
+        text_x,
+        text_width,
+        font,
+    )
+    _draw_bottom_row(
+        draw,
+        hour_minute,
+        temp_text,
+        text_x,
+        text_width,
+        font,
+    )
+
+    image = image.rotate(180)
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    png_data = buffer.getvalue()
+    _LOGGER.debug(
+        "Rendered weather clock PNG: condition=%s size=%dx%d payload=%d",
+        condition,
+        width,
+        height,
+        len(png_data),
+    )
+    return png_data
+
+
+def _load_font(font_name: str, font_size: float) -> ImageFont.ImageFont:
+    """Load configured pixel font."""
+    font_path = get_font_path(font_name)
+    if font_path:
+        _LOGGER.debug("Using weather clock font file: %s size=%.1f", font_path, font_size)
+        return ImageFont.truetype(str(font_path), font_size)
+
+    _LOGGER.warning("Weather clock font %s not found; using PIL default", font_name)
+    return ImageFont.load_default()
+
+
+def _draw_weather_icon(draw: ImageDraw.ImageDraw, condition: str, size: int) -> None:
+    """Draw a compact colorful weather icon in the left 16x16 cell."""
+    condition = (condition or "").lower()
+
+    if condition in {"sunny", "clear"}:
+        _draw_sun(draw, 8, 8)
+    elif condition == "clear-night":
+        _draw_moon(draw)
+    elif condition in {"partlycloudy", "partly-cloudy"}:
+        _draw_sun(draw, 6, 6, radius=3)
+        _draw_cloud(draw, x=4, y=8)
+    elif condition in {"cloudy", "fog"}:
+        _draw_cloud(draw, x=2, y=4)
+        if condition == "fog":
+            for y in (12, 14):
+                draw.line((2, y, size - 2, y), fill=(145, 170, 185))
+    elif condition in {"rainy", "pouring"}:
+        _draw_cloud(draw, x=2, y=2)
+        for x, y in ((4, 11), (8, 12), (12, 11)):
+            draw.line((x, y, x - 1, y + 2), fill=(50, 170, 255))
+    elif condition == "lightning":
+        _draw_cloud(draw, x=2, y=2)
+        draw.polygon([(8, 9), (6, 14), (10, 11), (8, 15)], fill=(255, 220, 40))
+    elif condition in {"snowy", "snowy-rainy"}:
+        _draw_cloud(draw, x=2, y=2)
+        for x, y in ((4, 13), (8, 12), (12, 13)):
+            draw.point((x, y), fill=(210, 240, 255))
+            draw.point((x - 1, y), fill=(210, 240, 255))
+            draw.point((x + 1, y), fill=(210, 240, 255))
+    else:
+        draw.ellipse((3, 3, 12, 12), outline=(80, 190, 255), width=2)
+        draw.point((8, 8), fill=(255, 255, 255))
+
+
+def _draw_sun(
+    draw: ImageDraw.ImageDraw,
+    cx: int,
+    cy: int,
+    radius: int = 4,
+) -> None:
+    """Draw a tiny sun."""
+    draw.ellipse(
+        (cx - radius, cy - radius, cx + radius, cy + radius),
+        fill=(255, 190, 30),
+    )
+    for x1, y1, x2, y2 in (
+        (cx, 0, cx, 2),
+        (cx, 14, cx, 15),
+        (0, cy, 2, cy),
+        (14, cy, 15, cy),
+        (2, 2, 3, 3),
+        (13, 2, 12, 3),
+        (2, 13, 3, 12),
+        (13, 13, 12, 12),
+    ):
+        draw.line((x1, y1, x2, y2), fill=(255, 225, 80))
+
+
+def _draw_moon(draw: ImageDraw.ImageDraw) -> None:
+    """Draw a tiny crescent moon."""
+    draw.ellipse((3, 2, 12, 12), fill=(245, 230, 150))
+    draw.ellipse((7, 1, 14, 10), fill=(0, 0, 0))
+    draw.point((13, 3), fill=(180, 220, 255))
+    draw.point((12, 12), fill=(180, 220, 255))
+
+
+def _draw_cloud(draw: ImageDraw.ImageDraw, x: int, y: int) -> None:
+    """Draw a tiny cloud."""
+    color = (185, 210, 225)
+    shade = (120, 150, 170)
+    draw.ellipse((x + 1, y + 1, x + 7, y + 7), fill=color)
+    draw.ellipse((x + 5, y - 1, x + 12, y + 7), fill=color)
+    draw.rectangle((x + 3, y + 4, x + 14, y + 9), fill=color)
+    draw.line((x + 3, y + 9, x + 14, y + 9), fill=shade)
+
+
+def _draw_fit_text(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    xy: tuple[int, int],
+    max_width: int,
+    font: ImageFont.ImageFont,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draw text if it fits, trimming from the end if needed."""
+    candidate = text
+    while candidate and _text_width(draw, candidate, font) > max_width:
+        candidate = candidate[:-1]
+    draw.text(xy, candidate, font=font, fill=fill)
+
+
+def _draw_date_row(
+    draw: ImageDraw.ImageDraw,
+    weekday_text: str,
+    date_text: str,
+    x: int,
+    max_width: int,
+    font: ImageFont.ImageFont,
+) -> None:
+    """Draw weekday in blue and date in white."""
+    y = -1
+    weekday_color = (80, 190, 255)
+    date_color = (245, 245, 245)
+    space_width = _text_width(draw, " ", font)
+    weekday_width = _text_width(draw, weekday_text, font)
+    date_x = x + weekday_width + space_width
+    available_date_width = max_width - weekday_width - space_width
+
+    draw.text((x, y), weekday_text, font=font, fill=weekday_color)
+    _draw_fit_text(
+        draw,
+        date_text,
+        (date_x, y),
+        available_date_width,
+        font,
+        fill=date_color,
+    )
+
+
+def _draw_bottom_row(
+    draw: ImageDraw.ImageDraw,
+    hour_minute: str,
+    temp_text: str,
+    x: int,
+    max_width: int,
+    font: ImageFont.ImageFont,
+) -> None:
+    """Draw temperature and time on the bottom row."""
+    y = 8
+    temp_color = (255, 120, 60)
+    draw.text((x, y), temp_text, font=font, fill=temp_color)
+    if temp_text != "--":
+        degree_x = x + _text_width(draw, temp_text, font) + 1
+        _draw_degree_dots(draw, degree_x, y + 1, fill=temp_color)
+
+    time_width = _text_width(draw, hour_minute, font)
+    draw.text(
+        (x + max_width - time_width, y),
+        hour_minute,
+        font=font,
+        fill=(255, 224, 120),
+    )
+
+
+def _draw_degree_dots(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    fill: tuple[int, int, int],
+) -> None:
+    """Draw a degree mark as four explicit pixels."""
+    for point in ((x, y), (x + 1, y), (x, y + 1), (x + 1, y + 1)):
+        draw.point(point, fill=fill)
+
+
+def _text_width(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    font: ImageFont.ImageFont,
+) -> int:
+    """Return text width."""
+    bbox = draw.textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0]
+
+
+def _format_temperature_value(temperature: float | int | None) -> str:
+    """Format temperature number; degree mark is drawn manually."""
+    if temperature is None:
+        return "--"
+    return f"{round(float(temperature))}"
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert a six-digit hex color to RGB."""
+    normalized = hex_color.lstrip("#")
+    if len(normalized) != 6:
+        raise ValueError(f"Invalid hex color length: {hex_color}")
+    return (
+        int(normalized[0:2], 16),
+        int(normalized[2:4], 16),
+        int(normalized[4:6], 16),
+    )

--- a/custom_components/ipixel_color/display/weather_clock_renderer.py
+++ b/custom_components/ipixel_color/display/weather_clock_renderer.py
@@ -37,6 +37,7 @@ def render_weather_clock_to_png(
     weekday_index: int,
     day: int,
     month: int,
+    custom_text: str | None = None,
     font_name: str = "7x5.ttf",
     font_size: float = 7.5,
     background_color: str = "000000",
@@ -55,8 +56,11 @@ def render_weather_clock_to_png(
 
     text_x = icon_width + icon_gap
     text_width = width - text_x
-    weekday_text = WEEKDAYS_TR[weekday_index]
-    date_text = f"{day} {MONTHS_TR[month - 1]}"
+    if custom_text:
+        weekday_text, date_text = _split_top_text(custom_text)
+    else:
+        weekday_text = WEEKDAYS_TR[weekday_index]
+        date_text = f"{day} {MONTHS_TR[month - 1]}"
     temp_text = _format_temperature_value(temperature)
 
     _draw_date_row(
@@ -219,6 +223,16 @@ def _draw_date_row(
         font,
         fill=date_color,
     )
+
+
+def _split_top_text(text: str) -> tuple[str, str]:
+    """Split custom top-row text into blue and white segments."""
+    parts = text.strip().split(maxsplit=1)
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], parts[1]
 
 
 def _draw_bottom_row(

--- a/custom_components/ipixel_color/number.py
+++ b/custom_components/ipixel_color/number.py
@@ -30,12 +30,7 @@ async def async_setup_entry(
     api = hass.data[DOMAIN][entry.entry_id]
     
     async_add_entities([
-        iPIXELFontSize(api, entry, address, name),
-        iPIXELLineSpacing(api, entry, address, name),
         iPIXELBrightness(api, entry, address, name),
-        iPIXELTextAnimation(hass, api, entry, address, name),
-        iPIXELTextSpeed(hass, api, entry, address, name),
-        iPIXELTextRainbow(hass, api, entry, address, name),
     ])
 
 
@@ -187,7 +182,7 @@ class iPIXELBrightness(NumberEntity, RestoreEntity):
 
     _attr_mode = NumberMode.SLIDER
     _attr_native_min_value = 1  # Minimum brightness (0 is invalid)
-    _attr_native_max_value = 100  # Maximum brightness
+    _attr_native_max_value = 10  # User-facing brightness scale
     _attr_native_step = 1
     _attr_icon = "mdi:brightness-6"
     _attr_entity_category = None
@@ -206,8 +201,8 @@ class iPIXELBrightness(NumberEntity, RestoreEntity):
         self._name = name
         self._attr_name = "Brightness"
         self._attr_unique_id = f"{address}_brightness"
-        self._attr_native_value = 50  # Default brightness is 50%
-        self._attr_entity_description = "Display brightness level (1-100)"
+        self._attr_native_value = 5  # Default brightness is 5/10
+        self._attr_entity_description = "Display brightness level (1-10)"
         
         # Device info for grouping in device registry
         self._attr_device_info = DeviceInfo(
@@ -227,15 +222,17 @@ class iPIXELBrightness(NumberEntity, RestoreEntity):
         if last_state is not None and last_state.state not in ("unknown", "unavailable"):
             try:
                 value = int(float(last_state.state))
-                if 1 <= value <= 100:
+                if value > 10:
+                    value = max(1, min(10, round(value / 10)))
+                if 1 <= value <= 10:
                     self._attr_native_value = value
                     _LOGGER.debug("Restored brightness: %d", self._attr_native_value)
                 else:
-                    _LOGGER.warning("Invalid brightness value %d, using default 50", value)
-                    self._attr_native_value = 50
+                    _LOGGER.warning("Invalid brightness value %d, using default 5", value)
+                    self._attr_native_value = 5
             except (ValueError, TypeError):
                 _LOGGER.warning("Could not restore brightness from: %s", last_state.state)
-                self._attr_native_value = 50
+                self._attr_native_value = 5
 
     @property
     def native_value(self) -> float | None:
@@ -245,19 +242,24 @@ class iPIXELBrightness(NumberEntity, RestoreEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the brightness."""
         brightness = int(value)
-        if 1 <= brightness <= 100:
+        if 1 <= brightness <= 10:
             try:
+                device_brightness = brightness * 10
                 # Send brightness command to device
-                success = await self._api.set_brightness(brightness)
+                success = await self._api.set_brightness(device_brightness)
                 if success:
                     self._attr_native_value = brightness
-                    _LOGGER.info("Brightness set to %d%%", brightness)
+                    _LOGGER.info(
+                        "Brightness set to %d/10 (%d%%)",
+                        brightness,
+                        device_brightness,
+                    )
                 else:
-                    _LOGGER.error("Failed to set brightness to %d%%", brightness)
+                    _LOGGER.error("Failed to set brightness to %d/10", brightness)
             except Exception as err:
                 _LOGGER.error("Error setting brightness: %s", err)
         else:
-            _LOGGER.error("Invalid brightness: %d (must be 1-100)", brightness)
+            _LOGGER.error("Invalid brightness: %d (must be 1-10)", brightness)
 
     @property
     def available(self) -> bool:

--- a/custom_components/ipixel_color/services.yaml
+++ b/custom_components/ipixel_color/services.yaml
@@ -68,6 +68,12 @@ display_weather_clock:
       selector:
         entity:
           domain: weather
+    custom_text:
+      name: Custom Text
+      description: Optional top-row text. If omitted, the Custom Text entity is used; if that is empty, the current date is used.
+      required: false
+      selector:
+        text:
     font_name:
       name: Font
       description: Font file to use for date, time, and temperature.

--- a/custom_components/ipixel_color/services.yaml
+++ b/custom_components/ipixel_color/services.yaml
@@ -52,3 +52,37 @@ display_text:
       default: [0, 0, 0]
       selector:
         color_rgb:
+display_weather_clock:
+  name: Display Weather Clock
+  description: Render a 96x16 bitmap layout with weather icon, date, clock, and temperature.
+  target:
+    entity:
+      integration: ipixel_color
+      domain: text
+  fields:
+    weather_entity:
+      name: Weather Entity
+      description: Weather entity used for condition and temperature.
+      required: false
+      default: weather.forecast_home
+      selector:
+        entity:
+          domain: weather
+    font_name:
+      name: Font
+      description: Font file to use for date, time, and temperature.
+      required: false
+      default: 7x5.ttf
+      selector:
+        text:
+    font_size:
+      name: Font Size
+      description: Font size for the weather clock layout.
+      required: false
+      default: 7.5
+      selector:
+        number:
+          min: 4
+          max: 16
+          step: 0.5
+          mode: box

--- a/custom_components/ipixel_color/strings.json
+++ b/custom_components/ipixel_color/strings.json
@@ -13,7 +13,17 @@
         "description": "Enter the Bluetooth address of your iPIXEL Color display manually.",
         "data": {
           "address": "Bluetooth Address",
-          "name": "Device Name"
+          "name": "Device Name",
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
+        }
+      },
+      "init": {
+        "title": "iPIXEL Display Options",
+        "description": "Set both width and height to override device detection. Use 0 for both to use the detected size.",
+        "data": {
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
         }
       },
       "bluetooth_confirm": {
@@ -36,6 +46,18 @@
       "discovery_failed": "Device discovery failed.",
       "no_devices_found": "No devices found.",
       "unknown": "Unknown error occurred."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "iPIXEL Display Options",
+        "description": "Set both width and height to override device detection. Use 0 for both to use the detected size.",
+        "data": {
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/ipixel_color/switch.py
+++ b/custom_components/ipixel_color/switch.py
@@ -32,10 +32,6 @@ async def async_setup_entry(
     
     async_add_entities([
         iPIXELSwitch(api, entry, address, name),
-        iPIXELAntialiasingSwitch(api, entry, address, name),
-        iPIXELAutoUpdateSwitch(api, entry, address, name),
-        iPIXELClock24HSwitch(hass, api, entry, address, name),
-        iPIXELClockShowDateSwitch(hass, api, entry, address, name),
     ])
 
 

--- a/custom_components/ipixel_color/text.py
+++ b/custom_components/ipixel_color/text.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
 
 
 class iPIXELTextDisplay(TextEntity, RestoreEntity):
-    """Representation of an iPIXEL Color text display."""
+    """Representation of an iPIXEL Color weather clock custom text field."""
 
     _attr_mode = TextMode.TEXT
     _attr_native_max = 500  # Maximum 500 characters per protocol
@@ -55,7 +55,7 @@ class iPIXELTextDisplay(TextEntity, RestoreEntity):
         self._entry = entry
         self._address = address
         self._name = name
-        self._attr_name = "Display"
+        self._attr_name = "Custom Text"
         self._attr_unique_id = f"{address}_text_display"
         self._current_text = ""
         self._available = True
@@ -103,18 +103,7 @@ class iPIXELTextDisplay(TextEntity, RestoreEntity):
             # Store the original text value (preserving \n as typed)
             self._current_text = value
             
-            # Check if auto-update is enabled
-            auto_update = await self._get_auto_update_setting()
-            if not auto_update:
-                _LOGGER.debug("Auto-update disabled - text stored but not sent to display. Use update button to refresh.")
-                return
-            
-            # Resolve templates and process escape sequences when sending to display
-            template_resolved = await resolve_template_variables(self.hass, value)
-            processed_text = template_resolved.replace('\\n', '\n').replace('\\t', '\t')
-            
-            # Auto-update is enabled, proceed with display update
-            await self._update_display(processed_text)
+            _LOGGER.debug("Weather clock custom text changed to: %s", value)
                 
         except iPIXELConnectionError as err:
             _LOGGER.error("Connection error while displaying text: %s", err)
@@ -156,5 +145,4 @@ class iPIXELTextDisplay(TextEntity, RestoreEntity):
         except Exception as err:
             _LOGGER.error("Error updating entity state: %s", err)
             self._available = False
-
 

--- a/custom_components/ipixel_color/translations/en.json
+++ b/custom_components/ipixel_color/translations/en.json
@@ -13,7 +13,17 @@
         "description": "Enter the Bluetooth address of your iPIXEL Color display manually.",
         "data": {
           "address": "Bluetooth Address",
-          "name": "Device Name"
+          "name": "Device Name",
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
+        }
+      },
+      "init": {
+        "title": "iPIXEL Display Options",
+        "description": "Set both width and height to override device detection. Use 0 for both to use the detected size.",
+        "data": {
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
         }
       },
       "bluetooth_confirm": {
@@ -36,6 +46,18 @@
       "discovery_failed": "Device discovery failed.",
       "no_devices_found": "No devices found.",
       "unknown": "Unknown error occurred."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "iPIXEL Display Options",
+        "description": "Set both width and height to override device detection. Use 0 for both to use the detected size.",
+        "data": {
+          "display_width": "Display Width Override",
+          "display_height": "Display Height Override"
+        }
+      }
     }
   },
   "entity": {

--- a/scripts/debug_render_textimage.py
+++ b/scripts/debug_render_textimage.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Render a 96x16 textimage payload for local debugging."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import types
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "custom_components" / "ipixel_color"
+
+
+def _load_renderer():
+    """Load the renderer without requiring Home Assistant to be installed."""
+    custom_components = types.ModuleType("custom_components")
+    custom_components.__path__ = [str(REPO_ROOT / "custom_components")]
+    sys.modules.setdefault("custom_components", custom_components)
+
+    ipixel_package = types.ModuleType("custom_components.ipixel_color")
+    ipixel_package.__path__ = [str(PACKAGE_ROOT)]
+    sys.modules.setdefault("custom_components.ipixel_color", ipixel_package)
+
+    display_package = types.ModuleType("custom_components.ipixel_color.display")
+    display_package.__path__ = [str(PACKAGE_ROOT / "display")]
+    sys.modules.setdefault("custom_components.ipixel_color.display", display_package)
+
+    for module_name, module_path in (
+        ("custom_components.ipixel_color.fonts", PACKAGE_ROOT / "fonts.py"),
+        (
+            "custom_components.ipixel_color.display.text_renderer",
+            PACKAGE_ROOT / "display" / "text_renderer.py",
+        ),
+    ):
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    return sys.modules[
+        "custom_components.ipixel_color.display.text_renderer"
+    ].render_text_to_png
+
+
+def main() -> int:
+    """Render TEST/TEST and validate image dimensions."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--width", type=int, default=96)
+    parser.add_argument("--height", type=int, default=16)
+    parser.add_argument("--font", default="5x5.ttf")
+    parser.add_argument("--font-size", type=float, default=7.0)
+    parser.add_argument("--line-spacing", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    render_text_to_png = _load_renderer()
+
+    png_data = render_text_to_png(
+        "TEST\nTEST",
+        args.width,
+        args.height,
+        antialias=False,
+        font_size=args.font_size,
+        font=args.font,
+        line_spacing=args.line_spacing,
+    )
+
+    output = args.output or REPO_ROOT / "debug_textimage_96x16.png"
+    output.write_bytes(png_data)
+
+    with Image.open(output) as image:
+        rendered_width, rendered_height = image.size
+        raw_rgb_payload = len(image.convert("RGB").tobytes())
+
+    expected_pixels = args.width * args.height
+    expected_rgb_payload = expected_pixels * 3
+    assert (rendered_width, rendered_height) == (args.width, args.height)
+    assert raw_rgb_payload == expected_rgb_payload
+
+    print(f"rendered={rendered_width}x{rendered_height}")
+    print(f"pixels={expected_pixels}")
+    print(f"raw_rgb_payload={raw_rgb_payload}")
+    print(f"png_payload={len(png_data)}")
+    print(f"output={output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/debug_render_weather_clock.py
+++ b/scripts/debug_render_weather_clock.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Render the 96x16 weather clock layout for local debugging."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "custom_components" / "ipixel_color"
+
+
+def _load_renderer():
+    """Load the renderer without requiring Home Assistant to be installed."""
+    custom_components = types.ModuleType("custom_components")
+    custom_components.__path__ = [str(REPO_ROOT / "custom_components")]
+    sys.modules.setdefault("custom_components", custom_components)
+
+    ipixel_package = types.ModuleType("custom_components.ipixel_color")
+    ipixel_package.__path__ = [str(PACKAGE_ROOT)]
+    sys.modules.setdefault("custom_components.ipixel_color", ipixel_package)
+
+    display_package = types.ModuleType("custom_components.ipixel_color.display")
+    display_package.__path__ = [str(PACKAGE_ROOT / "display")]
+    sys.modules.setdefault("custom_components.ipixel_color.display", display_package)
+
+    for module_name, module_path in (
+        ("custom_components.ipixel_color.fonts", PACKAGE_ROOT / "fonts.py"),
+        (
+            "custom_components.ipixel_color.display.weather_clock_renderer",
+            PACKAGE_ROOT / "display" / "weather_clock_renderer.py",
+        ),
+    ):
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    return sys.modules[
+        "custom_components.ipixel_color.display.weather_clock_renderer"
+    ].render_weather_clock_to_png
+
+
+def main() -> int:
+    """Render a sample weather clock layout."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--condition", default="sunny")
+    parser.add_argument("--temperature", type=float, default=24)
+    parser.add_argument("--time", default="22:45")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    render_weather_clock_to_png = _load_renderer()
+    png_data = render_weather_clock_to_png(
+        width=96,
+        height=16,
+        condition=args.condition,
+        temperature=args.temperature,
+        hour_minute=args.time,
+        weekday_index=5,
+        day=18,
+        month=5,
+    )
+
+    output = args.output or REPO_ROOT / "debug_weather_clock_96x16.png"
+    output.write_bytes(png_data)
+
+    with Image.open(output) as image:
+        width, height = image.size
+        raw_rgb_payload = len(image.convert("RGB").tobytes())
+
+    assert (width, height) == (96, 16)
+    assert raw_rgb_payload == 96 * 16 * 3
+
+    print(f"rendered={width}x{height}")
+    print(f"raw_rgb_payload={raw_rgb_payload}")
+    print(f"png_payload={len(png_data)}")
+    print(f"output={output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds explicit 96x16 display overrides, robust textimage rendering/upload validation, detailed BLE/render logging, and a custom weather clock bitmap service for 96x16 panels. Includes debug render helpers for validating 96x16 payload dimensions. Root cause: unknown device-info fallback and notification handling could force Unknown/64x16 behavior and break textimage uploads on 96x16 LED_BLE panels. Validated with Python compileall and 96x16 render helpers.